### PR TITLE
chore: (Backend)빌드 파일 수정, application.yml 추가

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -37,7 +37,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-storage'
-	implementation 'com.google.cloud.sql:postgres-socket-factory'
 	implementation 'com.bucket4j:bucket4j-core:8.10.1'
 
 	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0")

--- a/backend-spring/today-store/src/main/resources/application.yml
+++ b/backend-spring/today-store/src/main/resources/application.yml
@@ -1,0 +1,36 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}?sslmode=require
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 1
+  jpa:
+    hibernate:
+      ddl-auto: validate # update, none, validate
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 30MB
+
+server:
+  port: ${PORT:8080}
+
+app:
+  gcs:
+    bucket: ${GCS_BUCKET}
+    prefix: ${GCS_PREFIX:uploads/}
+    signed-url-enabled: ${SIGNED_URL_ENABLED:false}
+    signed-url-duration-minutes: ${SIGNED_URL_DURATION_MINUTES:15}


### PR DESCRIPTION
## Issue Number
closed #4 

## As-Is
- 백엔드 CI를 위해서 application.yml 파일이 repository에 존재하지 않음.
- CI에 활용되는 애플리케이션 설정에서 datasource 연결 방식이 현재 의존성(cloud sql socket factory)과 불일치.

## To-Be
- application.yml 파일 github repo에 포함(형식은 Notion Wiki "DP-34 GCP 인프라 구축"의 내용을 따로도록 하되, ddl-auto 설정은 update -> validate로 변경함).
- Wiki에 나타난 형식을 따르기 위해 기존에 존재했던 'com.google.cloud.sql:postgres-socket-factory' 의존성 제거.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
