### PR TITLE
[Build] backend Dockerfile 및 docker-compose 추가

### DIFF
--- a/backend-spring/today-store/.gitignore
+++ b/backend-spring/today-store/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+secrets/
 
 ### STS ###
 .apt_generated

--- a/backend-spring/today-store/Dockerfile
+++ b/backend-spring/today-store/Dockerfile
@@ -1,0 +1,19 @@
+FROM gradle:8.14.3-jdk21 AS build
+WORKDIR /workspace
+
+COPY gradlew gradlew
+COPY gradlew.bat gradlew.bat
+COPY gradle gradle
+COPY settings.gradle build.gradle ./
+COPY src src
+
+RUN chmod +x gradlew && ./gradlew --no-daemon clean bootJar
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /workspace/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend-spring/today-store/docker-compose.yml
+++ b/backend-spring/today-store/docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: testrun
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: testdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d testrun"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      PORT: 8080
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/testrun?sslmode=disable
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: testdb
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ""
+      GCS_BUCKET: today-store-dev-user-uploads
+      GCS_PREFIX: uploads/
+      GOOGLE_APPLICATION_CREDENTIALS: /app/secrets/gcp-sa.json
+    volumes:
+      - ./secrets/gcp-sa.json:/app/secrets/gcp-sa.json:ro
+    ports:
+      - "8080:8080"
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/backend-spring/today-store/src/main/resources/application.yml
+++ b/backend-spring/today-store/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 30MB
+  
+  ai:
+    model:
+      chat: none
 
 server:
   port: ${PORT:8080}


### PR DESCRIPTION
## Issue Number
closed #7 

## As-Is
- 백엔드 로컬 실행을 위한 Docker 및 docker-compose 작성 (backend, postgres, redis, gcs 통합 실행)

## To-Be
- `backend-spring/today-store/Dockerfile`을 추가해 backend 이미지를 일관되게 빌드/실행할 수 있도록 구성
- `backend-spring/today-store/docker-compose.yml`을 추가해 postgres, redis, backend를 한 번에 실행하도록 구성
- `backend-spring/today-store/secrets` 폴더 gitignore 처리
- Vertex AI 미설정으로 인한 backend 실행 실패를 spring.ai.model.chat=none을 `application.yml`에 적용하여 해결

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- Spring의 jpa hibernate ddl-auto 설정이 validate이므로 첫 실행시에 update로 table 생성 필요