### PR TITLE
[Feat] Backend - 인증 API 구현 및 rate limit, 에러 표준 구현

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'com.bucket4j:bucket4j-core:8.10.1'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0")
 

--- a/backend-spring/today-store/src/main/java/today_store/authentication/controller/AuthController.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/controller/AuthController.java
@@ -1,0 +1,73 @@
+package today_store.authentication.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import today_store.authentication.dto.LoginRequest;
+import today_store.authentication.dto.LoginResponse;
+import today_store.authentication.dto.RefreshTokenRequest;
+import today_store.authentication.dto.RefreshTokenResponse;
+import today_store.authentication.service.AuthenticationService;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.ratelimit.RateLimit;
+import today_store.common.ratelimit.RateLimitTier;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthenticationService authenticationService;
+
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @PostMapping("/oauth/login")
+    public ResponseEntity<LoginResponse> oauthLogin(@Valid @RequestBody LoginRequest loginRequest) {
+        LoginResponse response = authenticationService.oauthLogin(loginRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshTokenResponse> refreshToken(@Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
+        RefreshTokenResponse response = authenticationService.refreshToken(refreshTokenRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorizationHeader, Authentication authentication) {
+        if (authentication != null && authorizationHeader != null) {
+            String accessToken = resolveToken(authorizationHeader);
+            if (accessToken != null) {
+                authenticationService.logout(accessToken, authentication.getName());
+                return ResponseEntity.noContent().build();
+            }
+        }
+        throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
+    }
+
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> delete(@RequestHeader("Authorization") String authorizationHeader, Authentication authentication) {
+        if (authentication != null && authorizationHeader != null) {
+            String accessToken = resolveToken(authorizationHeader);
+            if (accessToken != null) {
+                authenticationService.deleteUser(accessToken, authentication.getName());
+                return ResponseEntity.noContent().build();
+            }
+        }
+        throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
+    }
+
+    private String resolveToken(String bearerToken) {
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/dto/LoginRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package today_store.authentication.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "소셜 로그인 제공자(provider)는 필수 항목입니다.")
+    private String provider;
+    
+    @NotBlank(message = "인가 코드(code)는 필수 항목입니다.")
+    private String code;
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/dto/LoginResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/dto/LoginResponse.java
@@ -1,0 +1,33 @@
+package today_store.authentication.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import today_store.authentication.entity.User;
+
+import java.util.UUID;
+
+@Data
+@Builder
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private UserDetails user;
+
+    @Data
+    @Builder
+    public static class UserDetails {
+        private UUID id;
+        private String email;
+        private String name;
+        private boolean isFirstLogin;
+
+        public static UserDetails from(User user, boolean isFirstLogin) {
+            return UserDetails.builder()
+                    .id(user.getId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .isFirstLogin(isFirstLogin)
+                    .build();
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/dto/RefreshTokenRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/dto/RefreshTokenRequest.java
@@ -1,0 +1,14 @@
+package today_store.authentication.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequest {
+    @NotBlank(message = "리프레시 토큰(refreshToken)은 필수 항목입니다.")
+    private String refreshToken;
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/dto/RefreshTokenResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/dto/RefreshTokenResponse.java
@@ -1,0 +1,13 @@
+package today_store.authentication.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RefreshTokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
@@ -1,6 +1,7 @@
 package today_store.authentication.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,9 +15,8 @@ import java.util.UUID;
 @Table(name = "users", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"provider", "provider_id"})
 })
-@Setter
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id
@@ -59,6 +59,18 @@ public class User {
         this.provider = provider;
         this.providerId = providerId;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void recordLogin() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
     }
 
 }

--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/InvalidOauthCodeException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/InvalidOauthCodeException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class InvalidOauthCodeException extends CustomException {
+    public InvalidOauthCodeException() {
+        super(ErrorCode.INVALID_OAUTH_CODE);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/InvalidRefreshTokenException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class InvalidRefreshTokenException extends CustomException {
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/UnsupportedProviderException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/UnsupportedProviderException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class UnsupportedProviderException extends CustomException {
+    public UnsupportedProviderException() {
+        super(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/UserDisabledException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/UserDisabledException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class UserDisabledException extends CustomException {
+    public UserDisabledException() {
+        super(ErrorCode.USER_DISABLED);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/UserNotFoundException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class UserNotFoundException extends CustomException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAccessDeniedHandler.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package today_store.authentication.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import today_store.common.dto.ErrorResponse;
+import today_store.common.exception.ErrorCode;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(ErrorCode.ACCESS_DENIED.getStatus().value())
+                .code(ErrorCode.ACCESS_DENIED.getCode())
+                .message(ErrorCode.ACCESS_DENIED.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAuthenticationEntryPoint.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package today_store.authentication.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import today_store.common.dto.ErrorResponse;
+import today_store.common.exception.ErrorCode;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(ErrorCode.AUTHENTICATION_REQUIRED.getStatus().value())
+                .code(ErrorCode.AUTHENTICATION_REQUIRED.getCode())
+                .message(ErrorCode.AUTHENTICATION_REQUIRED.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAuthenticationFilter.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package today_store.authentication.jwt;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+import today_store.authentication.repository.BlacklistedTokenRepository;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, BlacklistedTokenRepository blacklistedTokenRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.blacklistedTokenRepository = blacklistedTokenRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String jwt = resolveToken(httpServletRequest);
+        String requestURI = httpServletRequest.getRequestURI();
+
+        if (StringUtils.hasText(jwt)) {
+            if (blacklistedTokenRepository.existsById(jwt)) {
+                logger.info("Blacklisted token received, uri: " + requestURI);
+            } else if (jwtTokenProvider.validateToken(jwt)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                logger.debug("Invalid JWT Token, uri: " + requestURI);
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtTokenProvider.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/jwt/JwtTokenProvider.java
@@ -1,0 +1,124 @@
+package today_store.authentication.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    @Value("${jwt.secret-key}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration-seconds}")
+    private long accessTokenExpirationSeconds;
+
+    @Value("${jwt.refresh-token-expiration-seconds}")
+    private long refreshTokenExpirationSeconds;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return createToken(authentication, accessTokenExpirationSeconds);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return createToken(authentication, refreshTokenExpirationSeconds);
+    }
+
+    private String createToken(Authentication authentication, long expirationSeconds) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + expirationSeconds * 1000);
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .signWith(key)
+                .expiration(validity)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        String auth = claims.get(AUTHORITIES_KEY) == null ? "" : claims.get(AUTHORITIES_KEY).toString();
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(auth.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT token.");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.");
+        }
+        return false;
+    }
+
+    public Long getRemainingExpirationMillis(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            long expirationTime = claims.getExpiration().getTime();
+            long currentTime = System.currentTimeMillis();
+
+            return (expirationTime - currentTime) / 1000;
+        } catch (ExpiredJwtException e) {
+            return 0L;
+        } catch (Exception e) {
+            log.error("Error while getting remaining expiration time from token", e);
+            return 0L;
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/GoogleOAuth2UserInfo.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package today_store.authentication.oauth2;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/KakaoOAuth2UserInfo.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/KakaoOAuth2UserInfo.java
@@ -1,0 +1,34 @@
+package today_store.authentication.oauth2;
+
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties != null ? (String) properties.get("nickname") : null;
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties != null ? (String) properties.get("profile_image") : null;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/OAuth2UserInfo.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,20 @@
+package today_store.authentication.oauth2;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/OAuth2UserInfoFactory.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/oauth2/OAuth2UserInfoFactory.java
@@ -1,0 +1,15 @@
+package today_store.authentication.oauth2;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if (registrationId.equalsIgnoreCase("google")) {
+            return new GoogleOAuth2UserInfo(attributes);
+        } else if (registrationId.equalsIgnoreCase("kakao")) {
+            return new KakaoOAuth2UserInfo(attributes);
+        } else {
+            throw new IllegalArgumentException("Invalid Provider Type.");
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/BlacklistedTokenRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,9 @@
+package today_store.authentication.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import today_store.authentication.entity.BlacklistedToken;
+
+@Repository
+public interface BlacklistedTokenRepository extends CrudRepository<BlacklistedToken, String> {
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/BlacklistedTokenRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/BlacklistedTokenRepository.java
@@ -1,9 +1,7 @@
 package today_store.authentication.repository;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 import today_store.authentication.entity.BlacklistedToken;
 
-@Repository
 public interface BlacklistedTokenRepository extends CrudRepository<BlacklistedToken, String> {
 }

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/RefreshTokenRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package today_store.authentication.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import today_store.authentication.entity.RefreshToken;
+
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/RefreshTokenRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/RefreshTokenRepository.java
@@ -1,11 +1,9 @@
 package today_store.authentication.repository;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 import today_store.authentication.entity.RefreshToken;
 
 import java.util.UUID;
 
-@Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
 }

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package today_store.authentication.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import today_store.authentication.entity.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+}

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
@@ -1,13 +1,11 @@
 package today_store.authentication.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import today_store.authentication.entity.User;
 
 import java.util.Optional;
 import java.util.UUID;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
     Optional<User> findByProviderAndProviderId(String provider, String providerId);

--- a/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
@@ -48,6 +48,7 @@ public class AuthenticationService {
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final BlacklistedTokenRepository blacklistedTokenRepository;
+    private final WebClient webClient;
 
     public LoginResponse oauthLogin(LoginRequest loginRequest) {
         log.info("OAuth login attempt for provider: {}", loginRequest.getProvider());
@@ -190,9 +191,8 @@ public class AuthenticationService {
             log.info("Access token blacklisted for deleted user ID: {}", userId);
         }
 
-        // 3. Soft delete: Deactivate the user instead of physical deletion
+        // 3. Soft delete
         user.deactivate();
-        userRepository.save(user);
         log.info("User account successfully deactivated (soft delete). User ID: {}", userId);
     }
 
@@ -206,8 +206,7 @@ public class AuthenticationService {
         formData.add("code", code);
 
         try {
-            Map<String, Object> response = WebClient.create()
-                    .post()
+            Map<String, Object> response = webClient.post()
                     .uri(clientRegistration.getProviderDetails().getTokenUri())
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                     .bodyValue(formData)
@@ -238,8 +237,7 @@ public class AuthenticationService {
     private Map<String, Object> getUserAttributes(ClientRegistration clientRegistration, String token) {
         log.info("Requesting user attributes from {}", clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri());
         try {
-            Map<String, Object> userAttributes = WebClient.create()
-                    .get()
+            Map<String, Object> userAttributes = webClient.get()
                     .uri(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
                     .headers(header -> header.setBearerAuth(token))
                     .retrieve()

--- a/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
@@ -1,0 +1,294 @@
+package today_store.authentication.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import today_store.authentication.dto.LoginRequest;
+import today_store.authentication.dto.LoginResponse;
+import today_store.authentication.dto.RefreshTokenRequest;
+import today_store.authentication.dto.RefreshTokenResponse;
+import today_store.authentication.entity.BlacklistedToken;
+import today_store.authentication.entity.RefreshToken;
+import today_store.authentication.entity.User;
+import today_store.authentication.jwt.JwtTokenProvider;
+import today_store.authentication.oauth2.OAuth2UserInfo;
+import today_store.authentication.oauth2.OAuth2UserInfoFactory;
+import today_store.authentication.exception.InvalidOauthCodeException;
+import today_store.authentication.exception.InvalidRefreshTokenException;
+import today_store.authentication.exception.UserDisabledException;
+import today_store.authentication.exception.UserNotFoundException;
+import today_store.authentication.exception.UnsupportedProviderException;
+import today_store.authentication.repository.BlacklistedTokenRepository;
+import today_store.authentication.repository.RefreshTokenRepository;
+import today_store.authentication.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+    public LoginResponse oauthLogin(LoginRequest loginRequest) {
+        log.info("OAuth login attempt for provider: {}", loginRequest.getProvider());
+
+        ClientRegistration clientRegistration = Optional.ofNullable(clientRegistrationRepository.findByRegistrationId(loginRequest.getProvider()))
+                .orElseThrow(() -> {
+                    log.error("Unsupported provider: {}", loginRequest.getProvider());
+                    return new UnsupportedProviderException();
+                });
+
+        log.debug("Found client registration for: {}", clientRegistration.getClientName());
+
+        String token = getAccessToken(clientRegistration, loginRequest.getCode());
+        Map<String, Object> userAttributes = getUserAttributes(clientRegistration, token);
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(loginRequest.getProvider(), userAttributes);
+
+        String maskedEmail = oAuth2UserInfo.getEmail().replaceAll("(?<=.{3}).(?=.*@)", "*");
+        log.debug("OAuth2 User authenticated. Email: {}, Provider: {}", maskedEmail, loginRequest.getProvider());
+
+        boolean isNewUser = userRepository.findByProviderAndProviderId(loginRequest.getProvider(), oAuth2UserInfo.getId()).isEmpty();
+        if (isNewUser) {
+            log.info("New user detected: {}", maskedEmail);
+        } else {
+            log.info("Existing user detected: {}", maskedEmail);
+        }
+        User user = saveOrUpdate(oAuth2UserInfo, loginRequest.getProvider());
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getEmail(), null);
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        log.debug("Access token and refresh token created for user: {}", user.getId());
+
+        // Save refresh token to Redis
+        refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken));
+        log.info("Refresh token saved in Redis for user ID: {}", user.getId());
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(LoginResponse.UserDetails.from(user, isNewUser))
+                .build();
+    }
+
+    @Transactional
+    public RefreshTokenResponse refreshToken(RefreshTokenRequest request) {
+        String refreshToken = request.getRefreshToken();
+        log.info("Attempting to refresh token");
+
+        // 1. Validate refresh token
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("Invalid refresh token received");
+            throw new InvalidRefreshTokenException();
+        }
+
+        // 2. Extract user email and find user in DB
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> {
+                    log.error("User not found during token refresh: {}", authentication.getName());
+                    return new UserNotFoundException();
+                });
+
+        // 3. Verify refresh token in Redis
+        RefreshToken storedToken = refreshTokenRepository.findById(user.getId())
+                .orElseThrow(() -> {
+                    log.warn("Refresh token not found in storage for user ID: {}", user.getId());
+                    return new InvalidRefreshTokenException();
+                });
+
+        if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            log.warn("Mismatched refresh token. Potential reuse attack. User ID: {}", user.getId());
+            throw new InvalidRefreshTokenException();
+        }
+        log.debug("Refresh token validated for user: {}", user.getId());
+
+        // 4. Generate new tokens (rotation)
+        String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        log.debug("New access and refresh tokens generated for user: {}", user.getId());
+
+        // 5. Update refresh token in Redis
+        refreshTokenRepository.save(new RefreshToken(user.getId(), newRefreshToken));
+        log.info("New refresh token saved in Redis for user ID: {}", user.getId());
+
+        return RefreshTokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+    @Transactional
+    public void logout(String accessToken, String email) {
+        String maskedEmail = email.replaceAll("(?<=.{3}).(?=.*@)", "*");
+        log.info("Logout request for user: {}", maskedEmail);
+
+        // Blacklist the access token
+        Long remainingExpiration = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
+        if (remainingExpiration > 0) {
+            blacklistedTokenRepository.save(new BlacklistedToken(accessToken, "logout", remainingExpiration));
+            log.info("Access token blacklisted for user: {}", maskedEmail);
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElse(null);
+
+        if (user != null) {
+            refreshTokenRepository.deleteById(user.getId());
+            log.info("Refresh token deleted for user: {}", maskedEmail);
+        } else {
+            log.warn("User not found for logout: {}", maskedEmail);
+        }
+    }
+
+    @Transactional
+    public void deleteUser(String accessToken, String email) {
+        String maskedEmail = email.replaceAll("(?<=.{3}).(?=.*@)", "*");
+        log.info("Account deletion request for user: {}", maskedEmail);
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.error("User not found during account deletion: {}", maskedEmail);
+                    return new UserNotFoundException();
+                });
+
+        if (Boolean.FALSE.equals(user.getIsActive())) {
+            log.warn("Account deletion requested for already deactivated user: {}", maskedEmail);
+            throw new UserDisabledException();
+        }
+
+        UUID userId = user.getId();
+
+        // 1. Delete refresh token from Redis
+        refreshTokenRepository.deleteById(userId);
+        log.info("Refresh token deleted during account deletion for user ID: {}", userId);
+
+        // 2. Blacklist current access token to invalidate it immediately
+        Long remainingExpiration = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
+        if (remainingExpiration > 0) {
+            blacklistedTokenRepository.save(new BlacklistedToken(accessToken, "delete_account", remainingExpiration));
+            log.info("Access token blacklisted for deleted user ID: {}", userId);
+        }
+
+        // 3. Soft delete: Deactivate the user instead of physical deletion
+        user.deactivate();
+        userRepository.save(user);
+        log.info("User account successfully deactivated (soft delete). User ID: {}", userId);
+    }
+
+    private String getAccessToken(ClientRegistration clientRegistration, String code) {
+        log.debug("Requesting access token from provider endpoint: {}", clientRegistration.getProviderDetails().getTokenUri());
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientRegistration.getClientId());
+        formData.add("client_secret", clientRegistration.getClientSecret());
+        formData.add("redirect_uri", clientRegistration.getRedirectUri());
+        formData.add("code", code);
+
+        try {
+            Map<String, Object> response = WebClient.create()
+                    .post()
+                    .uri(clientRegistration.getProviderDetails().getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue(formData)
+                    .retrieve()
+                    .onStatus(org.springframework.http.HttpStatusCode::is4xxClientError, clientResponse -> {
+                        log.error("Client error while getting access token: {}", clientResponse.statusCode());
+                        return clientResponse.bodyToMono(String.class)
+                                .map(body -> new InvalidOauthCodeException());
+                    })
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .block();
+
+            String accessToken = (String) Optional.ofNullable(response)
+                    .map(r -> r.get("access_token"))
+                    .orElseThrow(() -> {
+                        log.error("Access token not found in provider response");
+                        return new InvalidOauthCodeException();
+                    });
+            log.debug("Access token received successfully.");
+            return accessToken;
+        } catch (Exception e) {
+            log.error("Error communicating with OAuth provider: ", e);
+            if (e instanceof InvalidOauthCodeException) throw (InvalidOauthCodeException) e;
+            throw new InvalidOauthCodeException();
+        }
+    }
+
+    private Map<String, Object> getUserAttributes(ClientRegistration clientRegistration, String token) {
+        log.info("Requesting user attributes from {}", clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri());
+        try {
+            Map<String, Object> userAttributes = WebClient.create()
+                    .get()
+                    .uri(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+                    .headers(header -> header.setBearerAuth(token))
+                    .retrieve()
+                    .onStatus(org.springframework.http.HttpStatusCode::isError, clientResponse -> {
+                        log.error("Error while getting user attributes: {}", clientResponse.statusCode());
+                        return clientResponse.bodyToMono(String.class)
+                                .map(body -> new InvalidOauthCodeException());
+                    })
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .block();
+
+            if (userAttributes == null) {
+                log.error("User attributes response is null");
+                throw new InvalidOauthCodeException();
+            }
+
+            log.debug("User attributes received successfully.");
+            return userAttributes;
+        } catch (Exception e) {
+            log.error("Error getting user attributes: ", e);
+            if (e instanceof InvalidOauthCodeException) throw (InvalidOauthCodeException) e;
+            throw new InvalidOauthCodeException();
+        }
+    }
+
+    private User saveOrUpdate(OAuth2UserInfo oAuth2UserInfo, String provider) {
+        User user = userRepository.findByProviderAndProviderId(provider, oAuth2UserInfo.getId())
+                .map(entity -> {
+                    log.info("Updating last login time for user: {}", entity.getId());
+                    entity.recordLogin();
+                    if (Boolean.FALSE.equals(entity.getIsActive())) {
+                        log.warn("Login attempt for deactivated user: {}", entity.getId());
+                        throw new UserDisabledException();
+                    }
+                    return entity;
+                })
+                .orElseGet(() -> {
+                    log.info("Creating new user with email: {}", oAuth2UserInfo.getId());
+                    return new User(
+                            oAuth2UserInfo.getEmail(),
+                            oAuth2UserInfo.getName(),
+                            provider,
+                            oAuth2UserInfo.getId(),
+                            oAuth2UserInfo.getImageUrl()
+                    );
+                });
+
+        return userRepository.save(user);
+    }
+
+
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/config/SecurityConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package today_store.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import today_store.authentication.jwt.JwtAccessDeniedHandler;
+import today_store.authentication.jwt.JwtAuthenticationEntryPoint;
+import today_store.authentication.jwt.JwtAuthenticationFilter;
+import today_store.authentication.jwt.JwtTokenProvider;
+import today_store.authentication.repository.BlacklistedTokenRepository;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BlacklistedTokenRepository blacklistedTokenRepository;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/oauth/login", "/api/v1/auth/refresh").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, blacklistedTokenRepository),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/config/WebClientConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/WebClientConfig.java
@@ -1,0 +1,32 @@
+package today_store.common.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        // HttpClient 설정을 통해 타임아웃 및 커넥션 풀 제어
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // connect timeout
+                .responseTimeout(Duration.ofSeconds(5))           // read timeout
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(5))
+                                .addHandlerLast(new WriteTimeoutHandler(5)));
+
+        return builder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024)) // 메모리 버퍼 2MB 확장
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/config/WebMvcConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package today_store.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import today_store.common.ratelimit.RateLimitInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/api/**");
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/dto/ErrorResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/dto/ErrorResponse.java
@@ -1,0 +1,29 @@
+package today_store.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private int status;
+    private String code;
+    private String message;
+    
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<FieldError> errors;
+    
+    private LocalDateTime timestamp;
+
+    @Getter
+    @Builder
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/CustomException.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package today_store.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package today_store.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Auth
+    MISSING_REQUIRED_FIELDS(HttpStatus.BAD_REQUEST, "A001", "Missing required fields."),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "A002", "Unsupported oauth provider."),
+    INVALID_OAUTH_CODE(HttpStatus.UNAUTHORIZED, "A003", "Invalid oauth code."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "Invalid or expired refresh token."),
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "A005", "Full authentication is required."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A006", "Access denied."),
+    USER_DISABLED(HttpStatus.FORBIDDEN, "A006", "Access denied. Your account has been deactivated."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A007", "User not found."),
+
+
+    // Rate Limit
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package today_store.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import today_store.common.dto.ErrorResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException: {}", e.getMessage());
+        
+        ErrorCode errorCode = ErrorCode.MISSING_REQUIRED_FIELDS;
+        BindingResult bindingResult = e.getBindingResult();
+        
+        List<ErrorResponse.FieldError> errors = bindingResult.getFieldErrors().stream()
+                .map(error -> ErrorResponse.FieldError.builder()
+                        .field(error.getField())
+                        .value(error.getRejectedValue() == null ? null : error.getRejectedValue().toString())
+                        .reason(error.getDefaultMessage())
+                        .build())
+                .collect(Collectors.toList());
+
+        ErrorResponse response = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .errors(errors)
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getErrorCode().getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception: ", e);
+        ErrorResponse response = ErrorResponse.builder()
+                .status(500)
+                .code("SYS001")
+                .message("Internal server error")
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(response, org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimit.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimit.java
@@ -1,0 +1,12 @@
+package today_store.common.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+    RateLimitTier tier() default RateLimitTier.MIDDLE;
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitExceededException.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitExceededException.java
@@ -1,0 +1,10 @@
+package today_store.common.ratelimit;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class RateLimitExceededException extends CustomException {
+    public RateLimitExceededException() {
+        super(ErrorCode.RATE_LIMIT_EXCEEDED);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitInterceptor.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,54 @@
+package today_store.common.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final RateLimitService rateLimitService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        RateLimit rateLimit = handlerMethod.getMethodAnnotation(RateLimit.class);
+        if (rateLimit == null) {
+            return true;
+        }
+
+        String identifier = getClientIdentifier(request);
+        if (!rateLimitService.tryConsume(identifier, rateLimit.tier())) {
+            throw new RateLimitExceededException();
+        }
+
+        return true;
+    }
+
+    private String getClientIdentifier(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        // If authenticated, use email as identifier
+        if (authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal())) {
+            return authentication.getName();
+        }
+        
+        // If not authenticated, use Client IP
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
@@ -1,0 +1,39 @@
+package today_store.common.ratelimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class RateLimitService {
+
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public boolean tryConsume(String key, RateLimitTier tier) {
+        String bucketKey = key + ":" + tier.name();
+        Bucket bucket = buckets.computeIfAbsent(bucketKey, k -> createNewBucket(tier));
+        
+        boolean allowed = bucket.tryConsume(1);
+        if (!allowed) {
+            log.warn("Rate limit exceeded for key: {} (Tier: {})", key, tier.name());
+        }
+        return allowed;
+    }
+
+    private Bucket createNewBucket(RateLimitTier tier) {
+        Bandwidth limit = Bandwidth.builder()
+                .capacity(tier.getCapacity())
+                .refillIntervally(tier.getCapacity(), tier.getDuration())
+                .build();
+
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitTier.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitTier.java
@@ -1,0 +1,17 @@
+package today_store.common.ratelimit;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum RateLimitTier {
+    HIGH(5, Duration.ofMinutes(1)),
+    MIDDLE(30, Duration.ofMinutes(1)),
+    LOW(100, Duration.ofMinutes(1));
+
+    private final int capacity;
+    private final Duration duration;
+}

--- a/backend-spring/today-store/src/main/resources/application.yml
+++ b/backend-spring/today-store/src/main/resources/application.yml
@@ -69,7 +69,7 @@ spring:
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expiration-seconds: 1800 # 30 minutes
-  refresh-token-expiration-seconds: 604800 # 7 days
+  refresh-token-expiration-seconds: 1209600 # 14 days
 
 
 server:

--- a/backend-spring/today-store/src/main/resources/application.yml
+++ b/backend-spring/today-store/src/main/resources/application.yml
@@ -29,6 +29,49 @@ spring:
     model:
       chat: none
 
+  # ============ OAuth2 설정 ==========
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+              - profile_image
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+  # ======= flyway(db 형상관리) 설정 =========
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-token-expiration-seconds: 1800 # 30 minutes
+  refresh-token-expiration-seconds: 604800 # 7 days
+
+
 server:
   port: ${PORT:8080}
 


### PR DESCRIPTION
## Issue Number
closed #12 

## As-Is
- 인증 API의 비즈니스로직, 엔드포인트가 미비함.
- jwt, oauth2, spring security에 기반한 인증 시스템 구축을 위한 config, 환경 변수 설정이 필요함.
- 코드베이스에 rate limit 정책이 반영되어 있지 않음. 
- API 명세의 Error response 구조를 반영하고 있지 않음.
- application.yml 에서 flyway 설정이 누락되어있었음.

## To-Be
1. 사용자 인증 API
    - User 엔티티 NoArgsConstructor Access level = Protected 적용, Setter annotation 제거
    - User, RefreshToken, BlacklistedToken 엔티티에 대응되는 JpaRepository 인터페이스 정의
    - 4개 사용자 인증 API(login, refresh, logout, delete-me) 비즈니스 로직 작성
    - 4개 사용자 인증 API 엔드포인트 매핑, Rate Limit(tier =HIGH) 적용. (AuthController.java)
    - login, refresh API의 request/response DTO 클래스 정의
    - 에러 표준 정의에 따라 사용자 인증 관련 커스텀 에러 클래스 정의(A002, A003, A004, A006, A007)

2. jwt, oauth2, spring security 설정
    - jwt 인증 필터 정의
    - security filter chain 작성 : jwt 필터 등록 및 authenticated와 permitAll 엔드포인트 구분.
    - application.yml : jwt, oauth2 client 설정 추가
    - oauth2 user 정보 추상화

3. Rate Limit 정책
    - rate limit tier 정의(HIGH, MIDDLE, LOW)
    - bucket4j 기반 rate limit 정책 구현(RatelimitService)
    - API 엔드포인트에 rate limit 적용을 위한 인터셉터 등록

4. 에러 표준 정의
    - A001, A005 exception 핸들러 정의, security filter chain 등록.
    - API 명세에 따라 에러코드 정의
    - erro response 포맷에 맞춘 DTO 클래스 정의

5. 기타
    - application.yml : 누락되었던 flyway 설정 추가
    - build.gradle : @Valid annotation 사용을 위한 spring validation 의존성 추가.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 해당 기능과 관련된 API response 예시를 postman colleciton에 추가함(Notion Wiki - API 엔드포인트 참고)
