### PR TITLE
[Fix] Backend 테스트 환경의 인증 설정 누락으로 인한 CI 실패 수정

### DIFF
--- a/backend-spring/today-store/src/test/resources/application.yml
+++ b/backend-spring/today-store/src/test/resources/application.yml
@@ -22,9 +22,43 @@ spring:
   ai:
     model:
       chat: none
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope:
+              - profile
+              - email
+            redirect-uri: http://localhost/test/oauth/google
+            authorization-grant-type: authorization_code
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+              - profile_image
+            redirect-uri: http://localhost/test/oauth/kakao
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+        provider:
+          kakao:
+            authorization-uri: https://example.test/oauth/authorize
+            token-uri: https://example.test/oauth/token
+            user-info-uri: https://example.test/user/me
+            user-name-attribute: id
+
+jwt:
+  secret-key: dG9kYXktc3RvcmUtand0LXNlY3JldC1kdW1teS1rZXktZm9yLXRlc3Q= #today-store-jwt-secret-dummy-key-for-test
+  access-token-expiration-seconds: 1800 # 30 minutes
+  refresh-token-expiration-seconds: 1209600 # 14 days
 
 server:
-  port: 0
+  port: 8080
 
 app:
   gcs:


### PR DESCRIPTION
## Issue Number
closed #17 

## As-Is
- Backend 테스트 환경에 필요한 인증 관련 설정 값이 누락되어 CI 테스트가 실패
- `jwt_secret_key`와 OAuth 설정이 없는 상태에서 Spring context가 정상적으로 실행하지 못함

## To-Be
- test 전용 `application.yml`에 `jwt_secret_key`를 추가
- test 실행에 필요한 dummy OAuth 값을 추가해 외부 실제 인증 값 없이도 통합 테스트가 통과하도록 구성

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
