### PR TITLE
[Build] Backend docker-compose 환경변수를 .env 기반으로 정리

### DIFF
--- a/backend-spring/today-store/.env.example
+++ b/backend-spring/today-store/.env.example
@@ -1,0 +1,18 @@
+# Backend runtime env for docker-compose
+# +) The service account JSON must exist at ./secrets/gcp-sa.json
+
+# JWT secret (Base64-encoded random value)
+# today-store-jwt-secret-dummy-key-for-test
+JWT_SECRET_KEY= dG9kYXktc3RvcmUtand0LXNlY3JldC1kdW1teS1rZXktZm9yLXRlc3Q=
+
+# OAuth2 client settings
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+KAKAO_REDIRECT_URI=
+
+# Storage settings
+GCS_BUCKET=
+GCS_PREFIX=uploads/

--- a/backend-spring/today-store/.gitignore
+++ b/backend-spring/today-store/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+.env
+.env.*
+!.env.example

--- a/backend-spring/today-store/docker-compose.yml
+++ b/backend-spring/today-store/docker-compose.yml
@@ -41,14 +41,20 @@ services:
       redis:
         condition: service_healthy
     environment:
-      PORT: 8080
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/testrun?sslmode=disable
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: testdb
-      REDIS_HOST: redis
-      REDIS_PASSWORD: ""
-      GCS_BUCKET: today-store-dev-user-uploads
-      GCS_PREFIX: uploads/
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PASSWORD: ""
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
+      KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
+      GCS_BUCKET: ${GCS_BUCKET}
+      GCS_PREFIX: ${GCS_PREFIX}
       GOOGLE_APPLICATION_CREDENTIALS: /app/secrets/gcp-sa.json
     volumes:
       - ./secrets/gcp-sa.json:/app/secrets/gcp-sa.json:ro


### PR DESCRIPTION
## Issue Number
closed #19 

## As-Is
- backend docker compose 실행에 필요한 더미 환경변수가 `docker-compose.yml` 내부에 직접 작성하는 방식

## To-Be
- docker compose 실행에 필요한 환경변수를 `.env.example`로 분리해 필요한 값을 명시
- `docker-compose.yml`이 `.env` 기반으로 값을 읽도록 수정
- `.env`파일을 gitignore에 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- `.env`파일은 `backend-spring/today-store`에 위치
- `backend-spring/today-store/secrets/gcp-sa.json`파일도 있어야 정상적으로 docker compose 실행 가능