### PR TITLE
[Feat] Backend - 사용자 프로필, 가게 프로필 관리 API 구현

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.example'
+group = 'com.today_store'
 version = '0.0.1'
 description = 'Today Store Backend project'
 

--- a/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
@@ -73,4 +73,10 @@ public class User {
         this.isActive = true;
     }
 
+    public void updateName(String name) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+    }
+
 }

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -17,6 +17,14 @@ public enum ErrorCode {
     USER_DISABLED(HttpStatus.FORBIDDEN, "A006", "Access denied. Your account has been deactivated."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A007", "User not found."),
 
+    // User
+    INVALID_NAME_FORMAT(HttpStatus.BAD_REQUEST, "U001", "Invalid name format"),
+
+    // Store
+    STORE_REQUIRED_FIELDS_MISSING(HttpStatus.BAD_REQUEST, "S001", "Store name and business type are required"),
+    STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "S002", "User already has a registered store"),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S003", "Store profile not found"),
+
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later.");

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package today_store.common.exception;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -13,15 +14,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final ValidationErrorResolver validationErrorResolver;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException: {}", e.getMessage());
-        
-        ErrorCode errorCode = ErrorCode.MISSING_REQUIRED_FIELDS;
+
         BindingResult bindingResult = e.getBindingResult();
+
+        String objectName = e.getBindingResult().getObjectName();
+        ErrorCode errorCode = validationErrorResolver.resolve(objectName);
         
         List<ErrorResponse.FieldError> errors = bindingResult.getFieldErrors().stream()
                 .map(error -> ErrorResponse.FieldError.builder()

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
@@ -1,0 +1,21 @@
+package today_store.common.exception;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class ValidationErrorResolver {
+    private final Map<String, ErrorCode> errorMapping = new HashMap<>();
+
+    public ValidationErrorResolver() {
+        // DTO ObjectName <-> ErrorCode 매핑
+        errorMapping.put("createStoreRequest", ErrorCode.STORE_REQUIRED_FIELDS_MISSING);
+        errorMapping.put("updateUserProfileRequest", ErrorCode.INVALID_NAME_FORMAT);
+    }
+
+    public ErrorCode resolve(String objectName) {
+        return errorMapping.getOrDefault(objectName, ErrorCode.MISSING_REQUIRED_FIELDS);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/controller/StoreController.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/controller/StoreController.java
@@ -13,6 +13,7 @@ import today_store.common.ratelimit.RateLimit;
 import today_store.common.ratelimit.RateLimitTier;
 import today_store.store.dto.*;
 import today_store.store.service.StoreService;
+import today_store.user.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,35 +21,29 @@ import today_store.store.service.StoreService;
 public class StoreController {
 
     private final StoreService storeService;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     @PostMapping
     @RateLimit(tier = RateLimitTier.MIDDLE)
     @ResponseStatus(HttpStatus.CREATED)
     public CreateStoreResponse createStore(@Valid @RequestBody CreateStoreRequest request, Authentication authentication) {
-        User user = getUser(authentication);
+        User user = userService.getUser(authentication);
         return storeService.createStore(user, request);
     }
 
     @GetMapping("/me")
     @RateLimit(tier = RateLimitTier.LOW)
     public StoreResponse getMyStore(Authentication authentication) {
-        User user = getUser(authentication);
+        User user = userService.getUser(authentication);
         return storeService.getStore(user);
     }
 
     @PatchMapping("/me")
     @RateLimit(tier = RateLimitTier.MIDDLE)
     public UpdateStoreResponse updateMyStore(@RequestBody UpdateStoreRequest request, Authentication authentication) {
-        User user = getUser(authentication);
-        return storeService.updateStore(user, request);
-    }
-
-    private User getUser(Authentication authentication) {
         if (authentication == null) {
             throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
         }
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return storeService.updateStore(authentication.getName(), request);
     }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/controller/StoreController.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/controller/StoreController.java
@@ -1,0 +1,54 @@
+package today_store.store.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import today_store.authentication.entity.User;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.ratelimit.RateLimit;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.store.dto.*;
+import today_store.store.service.StoreService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stores")
+public class StoreController {
+
+    private final StoreService storeService;
+    private final UserRepository userRepository;
+
+    @PostMapping
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateStoreResponse createStore(@Valid @RequestBody CreateStoreRequest request, Authentication authentication) {
+        User user = getUser(authentication);
+        return storeService.createStore(user, request);
+    }
+
+    @GetMapping("/me")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public StoreResponse getMyStore(Authentication authentication) {
+        User user = getUser(authentication);
+        return storeService.getStore(user);
+    }
+
+    @PatchMapping("/me")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    public UpdateStoreResponse updateMyStore(@RequestBody UpdateStoreRequest request, Authentication authentication) {
+        User user = getUser(authentication);
+        return storeService.updateStore(user, request);
+    }
+
+    private User getUser(Authentication authentication) {
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
+        }
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreRequest.java
@@ -1,0 +1,36 @@
+package today_store.store.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.store.entity.PreferredStyle;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateStoreRequest {
+    @NotBlank(message = "Store name is required")
+    private String storeName;
+
+    @NotBlank(message = "Business type is required")
+    private String businessType;
+
+    @NotBlank(message = "Address is required")
+    private String address;
+
+    @NotNull(message = "Latitude is required")
+    private BigDecimal latitude;
+
+    @NotNull(message = "Longitude is required")
+    private BigDecimal longitude;
+
+    private PreferredStyle preferredStyle;
+
+    private SnsInfo sns;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import today_store.store.entity.Store;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -15,4 +16,11 @@ import java.util.UUID;
 public class CreateStoreResponse {
     private UUID id;
     private LocalDateTime createdAt;
+
+    public static CreateStoreResponse from(Store store) {
+        return CreateStoreResponse.builder()
+                .id(store.getId())
+                .createdAt(store.getCreatedAt())
+                .build();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/CreateStoreResponse.java
@@ -1,0 +1,18 @@
+package today_store.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateStoreResponse {
+    private UUID id;
+    private LocalDateTime createdAt;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/SnsInfo.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/SnsInfo.java
@@ -1,0 +1,16 @@
+package today_store.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SnsInfo {
+    private String instagram;
+    private String naver;
+    private String karrot;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/StoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/StoreResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import today_store.store.entity.PreferredStyle;
+import today_store.store.entity.Store;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -22,4 +23,21 @@ public class StoreResponse {
     private BigDecimal longitude;
     private PreferredStyle preferredStyle;
     private SnsInfo sns;
+
+    public static StoreResponse from(Store store) {
+        return StoreResponse.builder()
+                .id(store.getId())
+                .storeName(store.getStoreName())
+                .businessType(store.getBusinessType())
+                .address(store.getAddress())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .preferredStyle(store.getPreferredStyle())
+                .sns(SnsInfo.builder()
+                        .instagram(store.getSnsInstagram())
+                        .naver(store.getSnsNaverUrl())
+                        .karrot(store.getSnsKarrotUrl())
+                        .build())
+                .build();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/StoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/StoreResponse.java
@@ -1,0 +1,25 @@
+package today_store.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.store.entity.PreferredStyle;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreResponse {
+    private UUID id;
+    private String storeName;
+    private String businessType;
+    private String address;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+    private PreferredStyle preferredStyle;
+    private SnsInfo sns;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreRequest.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import today_store.store.entity.PreferredStyle;
 
+import java.math.BigDecimal;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -18,4 +20,6 @@ public class UpdateStoreRequest {
     private String snsKarrotUrl;
     private String businessType;
     private String address;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreRequest.java
@@ -1,0 +1,21 @@
+package today_store.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.store.entity.PreferredStyle;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateStoreRequest {
+    private String storeName;
+    private PreferredStyle preferredStyle;
+    private String snsInstagram;
+    private String snsNaverUrl;
+    private String snsKarrotUrl;
+    private String businessType;
+    private String address;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreResponse.java
@@ -1,0 +1,18 @@
+package today_store.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateStoreResponse {
+    private UUID id;
+    private LocalDateTime updatedAt;
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/dto/UpdateStoreResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import today_store.store.entity.Store;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -15,4 +16,11 @@ import java.util.UUID;
 public class UpdateStoreResponse {
     private UUID id;
     private LocalDateTime updatedAt;
+
+    public static UpdateStoreResponse from(Store store) {
+        return UpdateStoreResponse.builder()
+                .id(store.getId())
+                .updatedAt(store.getUpdatedAt())
+                .build();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/entity/Store.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/entity/Store.java
@@ -69,7 +69,7 @@ public class Store {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public void update(String storeName, PreferredStyle preferredStyle, String snsInstagram, String snsNaverUrl, String snsKarrotUrl, String businessType, String address) {
+    public void update(String storeName, PreferredStyle preferredStyle, String snsInstagram, String snsNaverUrl, String snsKarrotUrl, String businessType, String address, BigDecimal latitude, BigDecimal longitude) {
         if (storeName != null) this.storeName = storeName;
         if (preferredStyle != null) this.preferredStyle = preferredStyle;
         if (snsInstagram != null) this.snsInstagram = snsInstagram;
@@ -77,5 +77,7 @@ public class Store {
         if (snsKarrotUrl != null) this.snsKarrotUrl = snsKarrotUrl;
         if (businessType != null) this.businessType = businessType;
         if (address != null) this.address = address;
+        if (latitude != null) this.latitude = latitude;
+        if (longitude != null) this.longitude = longitude;
     }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/entity/Store.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/entity/Store.java
@@ -1,11 +1,7 @@
 package today_store.store.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import today_store.authentication.entity.User;
@@ -22,9 +18,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "stores")
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Store {
 
@@ -73,4 +68,14 @@ public class Store {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public void update(String storeName, PreferredStyle preferredStyle, String snsInstagram, String snsNaverUrl, String snsKarrotUrl, String businessType, String address) {
+        if (storeName != null) this.storeName = storeName;
+        if (preferredStyle != null) this.preferredStyle = preferredStyle;
+        if (snsInstagram != null) this.snsInstagram = snsInstagram;
+        if (snsNaverUrl != null) this.snsNaverUrl = snsNaverUrl;
+        if (snsKarrotUrl != null) this.snsKarrotUrl = snsKarrotUrl;
+        if (businessType != null) this.businessType = businessType;
+        if (address != null) this.address = address;
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/store/exception/StoreAlreadyExistException.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/exception/StoreAlreadyExistException.java
@@ -1,0 +1,8 @@
+package today_store.store.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class StoreAlreadyExistException extends CustomException {
+    public StoreAlreadyExistException(){super(ErrorCode.STORE_ALREADY_EXISTS);}
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/exception/StoreNotFoundException.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/exception/StoreNotFoundException.java
@@ -1,0 +1,8 @@
+package today_store.store.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class StoreNotFoundException extends CustomException {
+    public StoreNotFoundException(){super(ErrorCode.STORE_NOT_FOUND);}
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/repository/StoreRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/repository/StoreRepository.java
@@ -1,0 +1,13 @@
+package today_store.store.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import today_store.authentication.entity.User;
+import today_store.store.entity.Store;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+    Optional<Store> findByUser(User user);
+    boolean existsByUser(User user);
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
@@ -1,0 +1,90 @@
+package today_store.store.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today_store.authentication.entity.User;
+import today_store.store.dto.*;
+import today_store.store.entity.PreferredStyle;
+import today_store.store.entity.Store;
+import today_store.store.exception.StoreAlreadyExistException;
+import today_store.store.exception.StoreNotFoundException;
+import today_store.store.repository.StoreRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public CreateStoreResponse createStore(User user, CreateStoreRequest request) {
+        if (storeRepository.existsByUser(user)) {
+            throw new StoreAlreadyExistException();
+        }
+
+        Store store = Store.builder()
+                .user(user)
+                .storeName(request.getStoreName())
+                .businessType(request.getBusinessType())
+                .address(request.getAddress())
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .preferredStyle(request.getPreferredStyle() != null ? request.getPreferredStyle() : PreferredStyle.CLEAN)
+                .snsInstagram(request.getSns() != null ? request.getSns().getInstagram() : null)
+                .snsNaverUrl(request.getSns() != null ? request.getSns().getNaver() : null)
+                .snsKarrotUrl(request.getSns() != null ? request.getSns().getKarrot() : null)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Store savedStore = storeRepository.save(store);
+        return CreateStoreResponse.builder()
+                .id(savedStore.getId())
+                .createdAt(savedStore.getCreatedAt())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public StoreResponse getStore(User user) {
+        Store store = storeRepository.findByUser(user)
+                .orElseThrow(StoreNotFoundException::new);
+
+        return StoreResponse.builder()
+                .id(store.getId())
+                .storeName(store.getStoreName())
+                .businessType(store.getBusinessType())
+                .address(store.getAddress())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .preferredStyle(store.getPreferredStyle())
+                .sns(SnsInfo.builder()
+                        .instagram(store.getSnsInstagram())
+                        .naver(store.getSnsNaverUrl())
+                        .karrot(store.getSnsKarrotUrl())
+                        .build())
+                .build();
+    }
+
+    @Transactional
+    public UpdateStoreResponse updateStore(User user, UpdateStoreRequest request) {
+        Store store = storeRepository.findByUser(user)
+                .orElseThrow(StoreNotFoundException::new);
+
+        store.update(
+                request.getStoreName(),
+                request.getPreferredStyle(),
+                request.getSnsInstagram(),
+                request.getSnsNaverUrl(),
+                request.getSnsKarrotUrl(),
+                request.getBusinessType(),
+                request.getAddress()
+        );
+
+        return UpdateStoreResponse.builder()
+                .id(store.getId())
+                .updatedAt(store.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
@@ -70,7 +70,9 @@ public class StoreService {
                 request.getSnsNaverUrl(),
                 request.getSnsKarrotUrl(),
                 request.getBusinessType(),
-                request.getAddress()
+                request.getAddress(),
+                request.getLatitude(),
+                request.getLongitude()
         );
 
         storeRepository.saveAndFlush(store);

--- a/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
+++ b/backend-spring/today-store/src/main/java/today_store/store/service/StoreService.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import today_store.authentication.entity.User;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
 import today_store.store.dto.*;
 import today_store.store.entity.PreferredStyle;
 import today_store.store.entity.Store;
@@ -18,6 +21,7 @@ import java.time.LocalDateTime;
 public class StoreService {
 
     private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public CreateStoreResponse createStore(User user, CreateStoreRequest request) {
@@ -40,10 +44,7 @@ public class StoreService {
                 .build();
 
         Store savedStore = storeRepository.save(store);
-        return CreateStoreResponse.builder()
-                .id(savedStore.getId())
-                .createdAt(savedStore.getCreatedAt())
-                .build();
+        return CreateStoreResponse.from(savedStore);
     }
 
     @Transactional(readOnly = true)
@@ -51,24 +52,14 @@ public class StoreService {
         Store store = storeRepository.findByUser(user)
                 .orElseThrow(StoreNotFoundException::new);
 
-        return StoreResponse.builder()
-                .id(store.getId())
-                .storeName(store.getStoreName())
-                .businessType(store.getBusinessType())
-                .address(store.getAddress())
-                .latitude(store.getLatitude())
-                .longitude(store.getLongitude())
-                .preferredStyle(store.getPreferredStyle())
-                .sns(SnsInfo.builder()
-                        .instagram(store.getSnsInstagram())
-                        .naver(store.getSnsNaverUrl())
-                        .karrot(store.getSnsKarrotUrl())
-                        .build())
-                .build();
+        return StoreResponse.from(store);
     }
 
     @Transactional
-    public UpdateStoreResponse updateStore(User user, UpdateStoreRequest request) {
+    public UpdateStoreResponse updateStore(String email, UpdateStoreRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         Store store = storeRepository.findByUser(user)
                 .orElseThrow(StoreNotFoundException::new);
 
@@ -82,9 +73,8 @@ public class StoreService {
                 request.getAddress()
         );
 
-        return UpdateStoreResponse.builder()
-                .id(store.getId())
-                .updatedAt(store.getUpdatedAt())
-                .build();
+        storeRepository.saveAndFlush(store);
+
+        return UpdateStoreResponse.from(store);
     }
 }

--- a/backend-spring/today-store/src/main/java/today_store/user/controller/UserController.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/controller/UserController.java
@@ -21,27 +21,20 @@ import today_store.user.service.UserService;
 public class UserController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
 
     @GetMapping("/me")
     @RateLimit(tier = RateLimitTier.LOW)
     public UserProfileResponse getMyProfile(Authentication authentication) {
-        User user = getUser(authentication);
+        User user = userService.getUser(authentication);
         return userService.getUserProfile(user);
     }
 
     @PatchMapping("/me")
     @RateLimit(tier = RateLimitTier.MIDDLE)
     public UpdateUserProfileResponse updateMyProfile(@Valid @RequestBody UpdateUserProfileRequest request, Authentication authentication) {
-        User user = getUser(authentication);
-        return userService.updateUserProfile(user, request);
-    }
-
-    private User getUser(Authentication authentication) {
         if (authentication == null) {
             throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
         }
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return userService.updateUserProfile(authentication.getName(), request);
     }
 }

--- a/backend-spring/today-store/src/main/java/today_store/user/controller/UserController.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/controller/UserController.java
@@ -1,0 +1,47 @@
+package today_store.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import today_store.authentication.entity.User;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.ratelimit.RateLimit;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.user.dto.UpdateUserProfileRequest;
+import today_store.user.dto.UpdateUserProfileResponse;
+import today_store.user.dto.UserProfileResponse;
+import today_store.user.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    @GetMapping("/me")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public UserProfileResponse getMyProfile(Authentication authentication) {
+        User user = getUser(authentication);
+        return userService.getUserProfile(user);
+    }
+
+    @PatchMapping("/me")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    public UpdateUserProfileResponse updateMyProfile(@Valid @RequestBody UpdateUserProfileRequest request, Authentication authentication) {
+        User user = getUser(authentication);
+        return userService.updateUserProfile(user, request);
+    }
+
+    private User getUser(Authentication authentication) {
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
+        }
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,18 @@
+package today_store.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserProfileRequest {
+    @NotBlank(message = "Name is required")
+    @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
+    private String name;
+}

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import today_store.authentication.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -15,4 +16,11 @@ import java.util.UUID;
 public class UpdateUserProfileResponse {
     private UUID id;
     private LocalDateTime updatedAt;
+
+    public static UpdateUserProfileResponse from(User user) {
+        return UpdateUserProfileResponse.builder()
+                .id(user.getId())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
@@ -1,0 +1,18 @@
+package today_store.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserProfileResponse {
+    private UUID id;
+    private LocalDateTime updatedAt;
+}

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UserProfileResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UserProfileResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import today_store.authentication.entity.User;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,4 +18,13 @@ public class UserProfileResponse {
     private String email;
     private String name;
     private LocalDateTime lastLoginAt;
+
+    public static UserProfileResponse from(User user) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .lastLoginAt(user.getLastLoginAt())
+                .build();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UserProfileResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UserProfileResponse.java
@@ -1,0 +1,20 @@
+package today_store.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+    private UUID id;
+    private String email;
+    private String name;
+    private LocalDateTime lastLoginAt;
+}

--- a/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
@@ -1,9 +1,13 @@
 package today_store.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import today_store.authentication.entity.User;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
 import today_store.user.dto.UpdateUserProfileRequest;
 import today_store.user.dto.UpdateUserProfileResponse;
 import today_store.user.dto.UserProfileResponse;
@@ -12,23 +16,33 @@ import today_store.user.dto.UserProfileResponse;
 @RequiredArgsConstructor
 public class UserService {
 
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User getUser(Authentication authentication) {
+        if (authentication == null) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_REQUIRED);
+        }
+
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(User user) {
-        return UserProfileResponse.builder()
-                .id(user.getId())
-                .email(user.getEmail())
-                .name(user.getName())
-                .lastLoginAt(user.getLastLoginAt())
-                .build();
+        return UserProfileResponse.from(user);
     }
 
     @Transactional
-    public UpdateUserProfileResponse updateUserProfile(User user, UpdateUserProfileRequest request) {
+    public UpdateUserProfileResponse updateUserProfile(String email, UpdateUserProfileRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         user.updateName(request.getName());
-        return UpdateUserProfileResponse.builder()
-                .id(user.getId())
-                .updatedAt(user.getUpdatedAt())
-                .build();
+
+        User updatedUser = userRepository.saveAndFlush(user);
+
+        return UpdateUserProfileResponse.from(updatedUser);
     }
 }
 

--- a/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
@@ -1,0 +1,34 @@
+package today_store.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today_store.authentication.entity.User;
+import today_store.user.dto.UpdateUserProfileRequest;
+import today_store.user.dto.UpdateUserProfileResponse;
+import today_store.user.dto.UserProfileResponse;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(User user) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .lastLoginAt(user.getLastLoginAt())
+                .build();
+    }
+
+    @Transactional
+    public UpdateUserProfileResponse updateUserProfile(User user, UpdateUserProfileRequest request) {
+        user.updateName(request.getName());
+        return UpdateUserProfileResponse.builder()
+                .id(user.getId())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}
+


### PR DESCRIPTION
## Issue Number
closed #16 
closed #20 

## As-Is
- 사용자 프로필 관리 비즈니스 로직과 엔드포인트 매핑 필요
- 가게 프로필 관리 비즈니스 로직과 엔드포인트 매핑 필요
- 추가되는 엔드포인트에 적용될 에러 코드 Enum 추가 필요
- vadlidation error 발생 시 에러를 발생시킨 요청 식별을 담당하는 컴포넌트가 없어 추후에 GlobalExceptionHandler 소스의 가독성이 저하될 수 있음.
- 빌드 파일 gruop명이 프로젝트 이름와 불일치(com.example)

## To-Be
- 사용자 프로필 조회, 업데이트 로직 추가, rate limit 적용된 엔드포인트 정의
- 가게 프로필 생성, 조회, 업데이트 로직 추가, rate limit 적용된 엔드포인트 정의
- 사용자 프로필 관리, 가게 프로필 관리에서 발생 가능한 에러 코드 추가(U001, S001, S002, S003)
- ValidationErrorResolver 추가 : validation error를 발생 시킨 요청을 GlobalExceptionHandler에서 ValidationErrorResolver 클래스가 식별하도록 위임.
- build.gradle : group 값을 com.example -> com.today_store로 수정하여 일관성 유지 

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 사용자, 가게 프로필 관리 API의 response example이 추가된 postman collection json 파일을 Notion Wiki - API 엔드포인트 문서에 업로드함.