### PR TITLE
[Feat] 생성 요청 정보 관리 API 구현

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/authentication/exception/AccessDeniedToResourceException.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/exception/AccessDeniedToResourceException.java
@@ -1,0 +1,10 @@
+package today_store.authentication.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class AccessDeniedToResourceException extends CustomException {
+    public AccessDeniedToResourceException() {
+        super(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/dto/PageRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/dto/PageRequest.java
@@ -1,0 +1,23 @@
+package today_store.common.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Setter
+public class PageRequest {
+
+    @Min(value = 1, message = "Page number should be greater than 1")
+    private int page = 1;
+
+    @Min(value = 1, message = "Page size should be greater than 1")
+    @Max(value = 100, message = "Page size cannot exceed 100")
+    private int size = 10;
+
+    public Pageable toPageable() {
+        return org.springframework.data.domain.PageRequest.of(page - 1, size);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "A006", "Access denied."),
     USER_DISABLED(HttpStatus.FORBIDDEN, "A006", "Access denied. Your account has been deactivated."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A007", "User not found."),
+    ACCESS_DENIED_TO_RESOURCE(HttpStatus.FORBIDDEN, "A008", "Access denied. Resource ownership mismatch."),
 
     // User
     INVALID_NAME_FORMAT(HttpStatus.BAD_REQUEST, "U001", "Invalid name format"),
@@ -25,6 +26,12 @@ public enum ErrorCode {
     STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "S002", "User already has a registered store"),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "S003", "Store profile not found"),
 
+    // Content/Generation Request
+    GENERATION_REQUEST_REQUIRED_FIELDS_MISSING(HttpStatus.BAD_REQUEST, "C001", "Missing required fields"),
+    FILE_NAME_MISMATCH(HttpStatus.BAD_REQUEST, "C002", "File name mismatch in imageConfigs"),
+    INVALID_REQUEST_BODY_FORMAT(HttpStatus.BAD_REQUEST, "C003", "Invalid request body format"),
+    FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "C004", "File size limit exceeded"),
+    GENERATION_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "Request not found or already deleted"),
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later.");

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -34,7 +34,10 @@ public enum ErrorCode {
     GENERATION_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "Request not found or already deleted"),
 
     // Rate Limit
-    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later.");
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later."),
+
+    // Page
+    INVALID_PAGE_PARAM(HttpStatus.BAD_REQUEST, "P001", "invalid (page, size) parameter");
 
     private final HttpStatus status;
     private final String code;

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import today_store.common.dto.ErrorResponse;
 
 import java.time.LocalDateTime;
@@ -42,6 +43,19 @@ public class GlobalExceptionHandler {
                 .code(errorCode.getCode())
                 .message(errorCode.getMessage())
                 .errors(errors)
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(org.springframework.web.multipart.MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.error("MaxUploadSizeExceededException: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.FILE_SIZE_LIMIT_EXCEEDED;
+        ErrorResponse response = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
                 .timestamp(LocalDateTime.now())
                 .build();
         return new ResponseEntity<>(response, errorCode.getStatus());

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
@@ -14,6 +14,9 @@ public class ValidationErrorResolver {
         errorMapping.put("createStoreRequest", ErrorCode.STORE_REQUIRED_FIELDS_MISSING);
         errorMapping.put("updateUserProfileRequest", ErrorCode.INVALID_NAME_FORMAT);
         errorMapping.put("createGenerationRequest", ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
+        errorMapping.put("pageRequest", ErrorCode.INVALID_PAGE_PARAM);
+        errorMapping.put("updateGenerationRequest", ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
+
     }
 
     public ErrorCode resolve(String objectName) {

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
@@ -13,6 +13,7 @@ public class ValidationErrorResolver {
         // DTO ObjectName <-> ErrorCode 매핑
         errorMapping.put("createStoreRequest", ErrorCode.STORE_REQUIRED_FIELDS_MISSING);
         errorMapping.put("updateUserProfileRequest", ErrorCode.INVALID_NAME_FORMAT);
+        errorMapping.put("createGenerationRequest", ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
     }
 
     public ErrorCode resolve(String objectName) {

--- a/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
@@ -1,0 +1,69 @@
+package today_store.common.gcs;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GcsService {
+
+    private final Storage storage;
+
+    @Value("${app.gcs.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file, String folder) {
+        String uuid = UUID.randomUUID().toString();
+        String objectName = folder + "/" + uuid + "_" + file.getOriginalFilename();
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName)
+                    .setContentType(file.getContentType())
+                    .build();
+            storage.create(blobInfo, file.getBytes());
+            log.info("Successfully uploaded file to GCS. ID: {}", uuid);
+            return objectName;
+        } catch (IOException e) {
+            log.error("Failed to upload file to GCS: {}", e.getMessage());
+            throw new RuntimeException("GCS upload failed", e);
+        }
+    }
+
+    public String generateSignedUrl(String objectName) {
+        if (objectName == null || objectName.isEmpty()) {
+            return null;
+        }
+
+        BlobId blobId = BlobId.of(bucketName, objectName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+
+        URL signedUrl = storage.signUrl(blobInfo, 15, TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());
+        return signedUrl.toString();
+    }
+
+    public void deleteFile(String objectName) {
+        if (objectName == null || objectName.isEmpty()) {
+            return;
+        }
+
+        boolean deleted = storage.delete(BlobId.of(bucketName, sanitize(objectName)));
+        if (!deleted) {
+            log.warn("File not found in GCS: {}", objectName);
+        }
+    }
+
+    private String sanitize(String input) {
+        return (input == null) ? "" : input.replaceAll("[\r\n]", " ");
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/controller/GenerationRequestController.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/controller/GenerationRequestController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import today_store.authentication.entity.User;
+import today_store.common.dto.PageRequest;
 import today_store.common.ratelimit.RateLimit;
 import today_store.common.ratelimit.RateLimitTier;
 import today_store.content.request.dto.*;
@@ -36,12 +37,11 @@ public class GenerationRequestController {
     @GetMapping("/requests")
     @RateLimit(tier = RateLimitTier.LOW)
     public GenerationRequestListResponse getRequests(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @Valid PageRequest pageRequest,
             Authentication authentication) {
 
         User user = userService.getUser(authentication);
-        return requestService.getRequests(user, page, size);
+        return requestService.getRequests(user, pageRequest.toPageable());
     }
 
     @GetMapping("/request/{requestId}")
@@ -64,7 +64,7 @@ public class GenerationRequestController {
         return requestService.updateRequest(authentication.getName(), requestId, request);
     }
 
-    @DeleteMapping("/{requestId}")
+    @DeleteMapping("/request/{requestId}")
     @RateLimit(tier = RateLimitTier.MIDDLE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteRequest(

--- a/backend-spring/today-store/src/main/java/today_store/content/request/controller/GenerationRequestController.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/controller/GenerationRequestController.java
@@ -1,0 +1,77 @@
+package today_store.content.request.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import today_store.authentication.entity.User;
+import today_store.common.ratelimit.RateLimit;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.content.request.dto.*;
+import today_store.content.request.service.GenerationRequestService;
+import today_store.user.service.UserService;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/contents")
+public class GenerationRequestController {
+
+    private final GenerationRequestService requestService;
+    private final UserService userService;
+
+    @PostMapping("/request")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public CreateGenerationResponse createRequest(
+            @Valid @ModelAttribute CreateGenerationRequest request,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return requestService.createRequest(user, request);
+    }
+
+    @GetMapping("/requests")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public GenerationRequestListResponse getRequests(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return requestService.getRequests(user, page, size);
+    }
+
+    @GetMapping("/request/{requestId}")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public GenerationRequestDetailResponse getRequestDetail(
+            @PathVariable UUID requestId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return requestService.getRequestDetail(user, requestId);
+    }
+
+    @PatchMapping("/request/{requestId}")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    public UpdateGenerationResponse updateRequest(
+            @PathVariable UUID requestId,
+            @Valid @ModelAttribute UpdateGenerationRequest request,
+            Authentication authentication) {
+
+        return requestService.updateRequest(authentication.getName(), requestId, request);
+    }
+
+    @DeleteMapping("/{requestId}")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteRequest(
+            @PathVariable UUID requestId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        requestService.deleteRequest(user, requestId);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationRequest.java
@@ -1,0 +1,26 @@
+package today_store.content.request.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateGenerationRequest {
+    @NotBlank(message = "Concept is required")
+    private String concept;
+
+    private String additionalNote;
+
+    @NotEmpty(message = "Image descriptions are required")
+    private List<String> imageDescriptions;
+
+    @NotEmpty(message = "At least one image file is required")
+    private List<MultipartFile> images;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationRequest.java
@@ -18,6 +18,10 @@ public class CreateGenerationRequest {
 
     private String additionalNote;
 
+    private String targetAge;
+
+    private String targetGender;
+
     @NotEmpty(message = "Image descriptions are required")
     private List<String> imageDescriptions;
 

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/CreateGenerationResponse.java
@@ -1,0 +1,26 @@
+package today_store.content.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.content.request.entity.GenerationRequest;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateGenerationResponse {
+    private UUID requestId;
+    private LocalDateTime createdAt;
+
+    public static CreateGenerationResponse from(GenerationRequest request) {
+        return CreateGenerationResponse.builder()
+                .requestId(request.getId())
+                .createdAt(request.getCreatedAt())
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
@@ -20,6 +20,8 @@ public class GenerationRequestDetailResponse {
     private UUID userId;
     private String concept;
     private String additionalNote;
+    private String targetAge;
+    private String targetGender;
     private LocalDateTime createdAt;
     private List<ImageResponse> images;
 
@@ -29,6 +31,8 @@ public class GenerationRequestDetailResponse {
                 .userId(request.getUser().getId())
                 .concept(request.getConcept())
                 .additionalNote(request.getAdditionalNote())
+                .targetAge(request.getTargetAge())
+                .targetGender(request.getTargetGender())
                 .createdAt(request.getCreatedAt())
                 .images(images)
                 .build();

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
@@ -1,0 +1,58 @@
+package today_store.content.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerationRequestDetailResponse {
+    private UUID id;
+    private UUID userId;
+    private String concept;
+    private String additionalNote;
+    private LocalDateTime createdAt;
+    private List<ImageResponse> images;
+
+    public static GenerationRequestDetailResponse from(GenerationRequest request, List<ImageResponse> images) {
+        return GenerationRequestDetailResponse.builder()
+                .id(request.getId())
+                .userId(request.getUser().getId())
+                .concept(request.getConcept())
+                .additionalNote(request.getAdditionalNote())
+                .createdAt(request.getCreatedAt())
+                .images(images)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImageResponse {
+        private UUID id;
+        private String url;
+        private String description;
+        private Integer displayOrder;
+        private LocalDateTime createdAt;
+
+        public static ImageResponse from(InputImage image, String signedUrl) {
+            return ImageResponse.builder()
+                    .id(image.getId())
+                    .url(signedUrl)
+                    .description(image.getDescription())
+                    .displayOrder(image.getDisplayOrder())
+                    .createdAt(image.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestDetailResponse.java
@@ -23,6 +23,7 @@ public class GenerationRequestDetailResponse {
     private String targetAge;
     private String targetGender;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
     private List<ImageResponse> images;
 
     public static GenerationRequestDetailResponse from(GenerationRequest request, List<ImageResponse> images) {
@@ -34,6 +35,7 @@ public class GenerationRequestDetailResponse {
                 .targetAge(request.getTargetAge())
                 .targetGender(request.getTargetGender())
                 .createdAt(request.getCreatedAt())
+                .updatedAt(request.getUpdatedAt())
                 .images(images)
                 .build();
     }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestListResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestListResponse.java
@@ -1,0 +1,75 @@
+package today_store.content.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerationRequestListResponse {
+    private List<GenerationRequestSummary> data;
+    private PaginationInfo pagination;
+
+    public static GenerationRequestListResponse from(List<GenerationRequestSummary> data, PaginationInfo pagination) {
+        return GenerationRequestListResponse.builder()
+                .data(data)
+                .pagination(pagination)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GenerationRequestSummary {
+        private UUID requestId;
+        private String concept;
+        private String thumbnailUrl;
+        private Integer imageCount;
+        private LocalDateTime createdAt;
+
+        public static GenerationRequestSummary from(GenerationRequest request, String thumbnailUrl, int imageCount) {
+            return GenerationRequestSummary.builder()
+                    .requestId(request.getId())
+                    .concept(request.getConcept())
+                    .thumbnailUrl(thumbnailUrl)
+                    .imageCount(imageCount)
+                    .createdAt(request.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PaginationInfo {
+        private Integer currentPage;
+        private Integer pageSize;
+        private Long totalCount;
+        private Integer totalPages;
+        private Boolean hasNext;
+        private Boolean hasPrevious;
+
+        public static PaginationInfo from(Page<?> page) {
+            return PaginationInfo.builder()
+                    .currentPage(page.getNumber() + 1)
+                    .pageSize(page.getSize())
+                    .totalCount(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .hasPrevious(page.hasPrevious())
+                    .build();
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestListResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/GenerationRequestListResponse.java
@@ -37,6 +37,7 @@ public class GenerationRequestListResponse {
         private String thumbnailUrl;
         private Integer imageCount;
         private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
 
         public static GenerationRequestSummary from(GenerationRequest request, String thumbnailUrl, int imageCount) {
             return GenerationRequestSummary.builder()
@@ -45,6 +46,7 @@ public class GenerationRequestListResponse {
                     .thumbnailUrl(thumbnailUrl)
                     .imageCount(imageCount)
                     .createdAt(request.getCreatedAt())
+                    .updatedAt(request.getUpdatedAt())
                     .build();
         }
     }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/ImageConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/ImageConfig.java
@@ -1,0 +1,19 @@
+package today_store.content.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageConfig {
+    private UUID id;
+    private String fileName;
+    private String description;
+    private Integer displayOrder;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
@@ -1,5 +1,6 @@
 package today_store.content.request.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,6 +16,9 @@ public class UpdateGenerationRequest {
     private String additionalNote;
     private String targetAge;
     private String targetGender;
+
+    @NotBlank(message = "imageConfigs are required")
     private String imageConfigs;   // JSON array of ImageConfig
+
     private List<MultipartFile> newImages;
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
@@ -1,0 +1,18 @@
+package today_store.content.request.dto;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateGenerationRequest {
+    private String concept;
+    private String additionalNote;
+    private String imageConfigs;   // JSON array of ImageConfig
+    private List<MultipartFile> newImages;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationRequest.java
@@ -13,6 +13,8 @@ import java.util.List;
 public class UpdateGenerationRequest {
     private String concept;
     private String additionalNote;
+    private String targetAge;
+    private String targetGender;
     private String imageConfigs;   // JSON array of ImageConfig
     private List<MultipartFile> newImages;
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
@@ -17,6 +17,8 @@ public class UpdateGenerationResponse {
     private UUID requestId;
     private String concept;
     private String additionalNote;
+    private String targetAge;
+    private String targetGender;
     private LocalDateTime updatedAt;
     private ImageSummary imageSummary;
 
@@ -25,6 +27,8 @@ public class UpdateGenerationResponse {
                 .requestId(request.getId())
                 .concept(request.getConcept())
                 .additionalNote(request.getAdditionalNote())
+                .targetAge(request.getTargetAge())
+                .targetGender(request.getTargetGender())
                 .updatedAt(LocalDateTime.now())
                 .imageSummary(imageSummary)
                 .build();

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
@@ -29,7 +29,7 @@ public class UpdateGenerationResponse {
                 .additionalNote(request.getAdditionalNote())
                 .targetAge(request.getTargetAge())
                 .targetGender(request.getTargetGender())
-                .updatedAt(LocalDateTime.now())
+                .updatedAt(request.getUpdatedAt())
                 .imageSummary(imageSummary)
                 .build();
     }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/dto/UpdateGenerationResponse.java
@@ -1,0 +1,50 @@
+package today_store.content.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.content.request.entity.GenerationRequest;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateGenerationResponse {
+    private UUID requestId;
+    private String concept;
+    private String additionalNote;
+    private LocalDateTime updatedAt;
+    private ImageSummary imageSummary;
+
+    public static UpdateGenerationResponse from(GenerationRequest request, ImageSummary imageSummary) {
+        return UpdateGenerationResponse.builder()
+                .requestId(request.getId())
+                .concept(request.getConcept())
+                .additionalNote(request.getAdditionalNote())
+                .updatedAt(LocalDateTime.now())
+                .imageSummary(imageSummary)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImageSummary {
+        private Integer totalCount;
+        private Integer addedCount;
+        private Integer deletedCount;
+
+        public static ImageSummary from(int totalCount, int addedCount, int deletedCount) {
+            return ImageSummary.builder()
+                    .totalCount(totalCount)
+                    .addedCount(addedCount)
+                    .deletedCount(deletedCount)
+                    .build();
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
@@ -31,6 +31,12 @@ public class GenerationRequest {
     @Column(name = "additional_note", columnDefinition = "TEXT")
     private String additionalNote;
 
+    @Column(name = "target_age", length = 50)
+    private String targetAge;
+
+    @Column(name = "target_gender", length = 20)
+    private String targetGender;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -42,9 +48,11 @@ public class GenerationRequest {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void update(String concept, String additionalNote) {
+    public void update(String concept, String additionalNote, String targetAge, String targetGender) {
         if (concept != null) this.concept = concept;
         if (additionalNote != null) this.additionalNote = additionalNote;
+        if (targetAge != null) this.targetAge = targetAge;
+        if (targetGender != null) this.targetGender = targetGender;
     }
 
     public void delete() {

--- a/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
@@ -1,11 +1,7 @@
 package today_store.content.request.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import today_store.authentication.entity.User;
 
@@ -15,9 +11,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "generation_requests")
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class GenerationRequest {
 
@@ -46,4 +41,14 @@ public class GenerationRequest {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void update(String concept, String additionalNote) {
+        if (concept != null) this.concept = concept;
+        if (additionalNote != null) this.additionalNote = additionalNote;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/entity/GenerationRequest.java
@@ -3,6 +3,7 @@ package today_store.content.request.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import today_store.authentication.entity.User;
 
 import java.time.LocalDateTime;
@@ -41,6 +42,9 @@ public class GenerationRequest {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @Column(name = "is_deleted", nullable = false)
     @Builder.Default
     private Boolean isDeleted = false;
@@ -48,11 +52,17 @@ public class GenerationRequest {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @PrePersist
+    public void onCreate() {
+        updatedAt = LocalDateTime.now();
+    }
+
     public void update(String concept, String additionalNote, String targetAge, String targetGender) {
         if (concept != null) this.concept = concept;
         if (additionalNote != null) this.additionalNote = additionalNote;
         if (targetAge != null) this.targetAge = targetAge;
         if (targetGender != null) this.targetGender = targetGender;
+        updatedAt = LocalDateTime.now();
     }
 
     public void delete() {

--- a/backend-spring/today-store/src/main/java/today_store/content/request/entity/InputImage.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/entity/InputImage.java
@@ -1,11 +1,7 @@
 package today_store.content.request.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -14,9 +10,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "input_images")
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class InputImage {
 
@@ -42,4 +37,9 @@ public class InputImage {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public void update(String description, Integer displayOrder) {
+        if (description != null) this.description = description;
+        if (displayOrder != null) this.displayOrder = displayOrder;
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/exception/FileNameMismatchException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/exception/FileNameMismatchException.java
@@ -1,0 +1,10 @@
+package today_store.content.request.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class FileNameMismatchException extends CustomException {
+    public FileNameMismatchException() {
+        super(ErrorCode.FILE_NAME_MISMATCH);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/exception/GenerationRequestNotFoundException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/exception/GenerationRequestNotFoundException.java
@@ -1,0 +1,10 @@
+package today_store.content.request.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class GenerationRequestNotFoundException extends CustomException {
+    public GenerationRequestNotFoundException() {
+        super(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/exception/InvalidRequestBodyFormatException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/exception/InvalidRequestBodyFormatException.java
@@ -1,0 +1,10 @@
+package today_store.content.request.exception;
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class InvalidRequestBodyFormatException extends CustomException {
+    public InvalidRequestBodyFormatException() {
+        super(ErrorCode.INVALID_REQUEST_BODY_FORMAT);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/repository/GenerationRequestRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/repository/GenerationRequestRepository.java
@@ -1,0 +1,15 @@
+package today_store.content.request.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import today_store.authentication.entity.User;
+import today_store.content.request.entity.GenerationRequest;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GenerationRequestRepository extends JpaRepository<GenerationRequest, UUID> {
+    Page<GenerationRequest> findByUserAndIsDeletedFalseOrderByCreatedAtDesc(User user, Pageable pageable);
+    Optional<GenerationRequest> findByIdAndIsDeletedFalse(UUID id);
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/repository/InputImageRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/repository/InputImageRepository.java
@@ -1,0 +1,12 @@
+package today_store.content.request.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface InputImageRepository extends JpaRepository<InputImage, UUID> {
+    List<InputImage> findByGenerationRequestOrderByDisplayOrderAsc(GenerationRequest generationRequest);
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
@@ -55,6 +55,8 @@ public class GenerationRequestService {
                 .user(user)
                 .concept(request.getConcept())
                 .additionalNote(request.getAdditionalNote())
+                .targetAge(request.getTargetAge())
+                .targetGender(request.getTargetGender())
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -185,7 +187,7 @@ public class GenerationRequestService {
             throw new AccessDeniedToResourceException();
         }
 
-        generationRequest.update(request.getConcept(), request.getAdditionalNote());
+        generationRequest.update(request.getConcept(), request.getAdditionalNote(), request.getTargetAge(), request.getTargetGender());
 
         // 2. 상태 동기화 (삭제 로직 자동화)
         List<InputImage> currentImages = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest);
@@ -251,6 +253,9 @@ public class GenerationRequestService {
 
         log.info("Update completed for request {}. Added: {}, Deleted: {}, Final Count: {}",
                 requestId, addedCount, deletedCount, finalImages.size());
+
+        requestRepository.saveAndFlush(generationRequest);
+
         return UpdateGenerationResponse.from(generationRequest, imageSummary);
     }
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 import today_store.authentication.entity.User;
 import today_store.authentication.exception.AccessDeniedToResourceException;
@@ -84,9 +86,8 @@ public class GenerationRequestService {
     }
 
     @Transactional(readOnly = true)
-    public GenerationRequestListResponse getRequests(User user, int page, int size) {
-        log.debug("Fetching requests for user: {}, page: {}, size: {}", user.getId(), page, size);
-        Pageable pageable = PageRequest.of(page - 1, size);
+    public GenerationRequestListResponse getRequests(User user, Pageable pageable) {
+        log.debug("Fetching requests for user: {}, pageable: {}", user.getId(), pageable);
         Page<GenerationRequest> requestPage = requestRepository.findByUserAndIsDeletedFalseOrderByCreatedAtDesc(user, pageable);
 
         List<GenerationRequestListResponse.GenerationRequestSummary> data = requestPage.getContent().stream()
@@ -196,11 +197,12 @@ public class GenerationRequestService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
+        List<String> urlsToDelete = new ArrayList<>();
         int deletedCount = 0;
         for (InputImage img : currentImages) {
             if (!keepIds.contains(img.getId())) {
                 log.debug("Deleting image {} as it's not in the update configuration (State Sync)", img.getId());
-                gcsService.deleteFile(img.getUrl());
+                urlsToDelete.add(img.getUrl());
                 imageRepository.delete(img);
                 deletedCount++;
             }
@@ -248,13 +250,34 @@ public class GenerationRequestService {
             }
         }
 
+        // 5. 트랜잭션 커밋 성공 후 GCS 실제 삭제를 위한 동기화 등록
+        if (!urlsToDelete.isEmpty()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    log.debug("Transaction committed. Starting GCS file cleanup for {} files.",
+                            urlsToDelete.size());
+                    urlsToDelete.forEach(url -> {
+                        try {
+                            gcsService.deleteFile(url);
+                        } catch (Exception e) {
+                            log.error("Failed to delete GCS file after commit: {}", url, e);
+                        }
+                    });
+                }
+            });
+        }
+
+
+        requestRepository.saveAndFlush(generationRequest);
+
         List<InputImage> finalImages = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest);
         UpdateGenerationResponse.ImageSummary imageSummary = UpdateGenerationResponse.ImageSummary.from(finalImages.size(), addedCount, deletedCount);
 
         log.info("Update completed for request {}. Added: {}, Deleted: {}, Final Count: {}",
                 requestId, addedCount, deletedCount, finalImages.size());
 
-        requestRepository.saveAndFlush(generationRequest);
+
 
         return UpdateGenerationResponse.from(generationRequest, imageSummary);
     }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
@@ -1,0 +1,256 @@
+package today_store.content.request.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import today_store.authentication.entity.User;
+import today_store.authentication.exception.AccessDeniedToResourceException;
+import today_store.authentication.exception.UserNotFoundException;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gcs.GcsService;
+import today_store.content.request.dto.*;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+import today_store.content.request.exception.FileNameMismatchException;
+import today_store.content.request.exception.GenerationRequestNotFoundException;
+import today_store.content.request.exception.InvalidRequestBodyFormatException;
+import today_store.content.request.repository.GenerationRequestRepository;
+import today_store.content.request.repository.InputImageRepository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GenerationRequestService {
+
+    private final GenerationRequestRepository requestRepository;
+    private final InputImageRepository imageRepository;
+    private final UserRepository userRepository;
+    private final GcsService gcsService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public CreateGenerationResponse createRequest(User user, CreateGenerationRequest request) {
+        log.info("Creating generation request for user ID: {}, concept: {}", user.getId(), request.getConcept());
+
+        if (request.getImages().size() != request.getImageDescriptions().size()) {
+            log.warn("Mismatched image files and descriptions for user ID: {}", user.getId());
+            throw new CustomException(ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
+        }
+
+        GenerationRequest generationRequest = GenerationRequest.builder()
+                .user(user)
+                .concept(request.getConcept())
+                .additionalNote(request.getAdditionalNote())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        GenerationRequest savedRequest = requestRepository.save(generationRequest);
+        log.debug("Saved generation request entity. ID: {}", savedRequest.getId());
+
+        for (int i = 0; i < request.getImages().size(); i++) {
+            MultipartFile imageFile = request.getImages().get(i);
+            String description = request.getImageDescriptions().get(i);
+
+            log.debug("Uploading image {}/{} for request ID: {}", (i + 1), request.getImages().size(), savedRequest.getId());
+            String url = gcsService.uploadFile(imageFile, "requests/" + savedRequest.getId());
+
+            InputImage inputImage = InputImage.builder()
+                    .generationRequest(savedRequest)
+                    .url(url)
+                    .description(description)
+                    .displayOrder(i + 1)
+                    .build();
+            imageRepository.save(inputImage);
+        }
+
+        log.info("Generation request created successfully. ID: {}, User: {}", savedRequest.getId(), user.getId());
+        return CreateGenerationResponse.from(savedRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public GenerationRequestListResponse getRequests(User user, int page, int size) {
+        log.debug("Fetching requests for user: {}, page: {}, size: {}", user.getId(), page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<GenerationRequest> requestPage = requestRepository.findByUserAndIsDeletedFalseOrderByCreatedAtDesc(user, pageable);
+
+        List<GenerationRequestListResponse.GenerationRequestSummary> data = requestPage.getContent().stream()
+                .map(this::toSummary)
+                .collect(Collectors.toList());
+
+        GenerationRequestListResponse.PaginationInfo pagination = GenerationRequestListResponse.PaginationInfo.from(requestPage);
+
+        return GenerationRequestListResponse.from(data, pagination);
+    }
+
+    private GenerationRequestListResponse.GenerationRequestSummary toSummary(GenerationRequest request) {
+        List<InputImage> images = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request);
+        String thumbnailUrl = images.isEmpty() ? null : gcsService.generateSignedUrl(images.get(0).getUrl());
+
+        return GenerationRequestListResponse.GenerationRequestSummary.from(request, thumbnailUrl, images.size());
+    }
+
+    @Transactional(readOnly = true)
+    public GenerationRequestDetailResponse getRequestDetail(User user, UUID requestId) {
+        log.debug("Fetching request detail. ID: {}, User: {}", requestId, user.getId());
+        GenerationRequest request = requestRepository.findByIdAndIsDeletedFalse(requestId)
+                .orElseThrow(() -> {
+                    log.warn("Generation request not found: {}", requestId);
+                    return new GenerationRequestNotFoundException();
+                });
+
+        if (!request.getUser().getId().equals(user.getId())) {
+            log.warn("Access denied: User {} attempted to access request {} owned by {}",
+                    user.getId(), requestId, request.getUser().getId());
+            throw new AccessDeniedToResourceException();
+        }
+
+        List<InputImage> images = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request);
+        List<GenerationRequestDetailResponse.ImageResponse> imageResponses = images.stream()
+                .map(this::toImageResponse)
+                .collect(Collectors.toList());
+
+        return GenerationRequestDetailResponse.from(request, imageResponses);
+    }
+
+    private GenerationRequestDetailResponse.ImageResponse toImageResponse(InputImage image) {
+        return GenerationRequestDetailResponse.ImageResponse.from(image, gcsService.generateSignedUrl(image.getUrl()));
+    }
+
+    @Transactional
+    public void deleteRequest(User user, UUID requestId) {
+        log.info("Delete request for ID: {} by user: {}", requestId, user.getId());
+        GenerationRequest request = requestRepository.findByIdAndIsDeletedFalse(requestId)
+                .orElseThrow(() -> {
+                    log.warn("Generation request not found for deletion: {}", requestId);
+                    return new GenerationRequestNotFoundException();
+                });
+
+        if (!request.getUser().getId().equals(user.getId())) {
+            log.warn("Access denied for deletion: User {} attempted to delete request {} owned by {}",
+                    user.getId(), requestId, request.getUser().getId());
+            throw new AccessDeniedToResourceException();
+        }
+
+        // soft delete
+        request.delete();
+        log.info("Generation request soft-deleted successfully. ID: {}", requestId);
+    }
+
+    @Transactional
+    public UpdateGenerationResponse updateRequest(String email, UUID requestId, UpdateGenerationRequest request) {
+        String maskedEmail = email.replaceAll("(?<=.{3}).(?=.*@)", "*");
+        log.info("Update requested for ID: {} by user: {}", requestId, maskedEmail);
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.error("User not found during request update: {}", maskedEmail);
+                    return new UserNotFoundException();
+                });
+
+        // 1. parse imageConfigs
+        List<ImageConfig> configs = new ArrayList<>();
+        if (request.getImageConfigs() != null) {
+            try {
+                configs = objectMapper.readValue(request.getImageConfigs(), new TypeReference<List<ImageConfig>>() {
+                });
+            } catch (JsonProcessingException e) {
+                log.error("imageConfigs JSON parsing failed for user: {}, requestId: {}", user.getId(), requestId);
+                throw new InvalidRequestBodyFormatException();
+            }
+        }
+
+        GenerationRequest generationRequest = requestRepository.findByIdAndIsDeletedFalse(requestId)
+                .orElseThrow(() -> {
+                    log.warn("Generation request not found for update: {}", requestId);
+                    return new GenerationRequestNotFoundException();
+                });
+
+        if (!generationRequest.getUser().getId().equals(user.getId())) {
+            log.warn("Access denied for update: User {} attempted to update request {} owned by {}",
+                    user.getId(), requestId, generationRequest.getUser().getId());
+            throw new AccessDeniedToResourceException();
+        }
+
+        generationRequest.update(request.getConcept(), request.getAdditionalNote());
+
+        // 2. 상태 동기화 (삭제 로직 자동화)
+        List<InputImage> currentImages = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest);
+        Set<UUID> keepIds = configs.stream()
+                .map(ImageConfig::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        int deletedCount = 0;
+        for (InputImage img : currentImages) {
+            if (!keepIds.contains(img.getId())) {
+                log.debug("Deleting image {} as it's not in the update configuration (State Sync)", img.getId());
+                gcsService.deleteFile(img.getUrl());
+                imageRepository.delete(img);
+                deletedCount++;
+            }
+        }
+
+        // 3. 수정 및 신규 추가 처리
+        int addedCount = 0;
+        if (!configs.isEmpty()) {
+            Map<String, MultipartFile> fileMap = new HashMap<>();
+            if (request.getNewImages() != null) {
+                for (MultipartFile file : request.getNewImages()) {
+                    fileMap.put(file.getOriginalFilename(), file);
+                }
+            }
+
+            for (ImageConfig config : configs) {
+                if (config.getId() != null) {
+                    // 기존 이미지 정보 업데이트
+                    InputImage img = imageRepository.findById(config.getId())
+                            .orElseThrow(GenerationRequestNotFoundException::new);
+
+                    if (!img.getGenerationRequest().getId().equals(requestId)) {
+                        log.warn("Security alert: Attempt to update image {} belonging to request {}", config.getId(), img.getGenerationRequest().getId());
+                        throw new AccessDeniedToResourceException();
+                    }
+
+                    img.update(config.getDescription(), config.getDisplayOrder());
+                } else {
+                    // 신규 이미지 추가
+                    MultipartFile file = fileMap.get(config.getFileName());
+                    if (file == null) {
+                        log.warn("File name mismatch during update: {}", config.getFileName());
+                        throw new FileNameMismatchException();
+                    }
+                    String url = gcsService.uploadFile(file, "requests/" + requestId);
+                    InputImage newImg = InputImage.builder()
+                            .generationRequest(generationRequest)
+                            .url(url)
+                            .description(config.getDescription())
+                            .displayOrder(config.getDisplayOrder())
+                            .build();
+                    imageRepository.save(newImg);
+                    addedCount++;
+                }
+            }
+        }
+
+        List<InputImage> finalImages = imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest);
+        UpdateGenerationResponse.ImageSummary imageSummary = UpdateGenerationResponse.ImageSummary.from(finalImages.size(), addedCount, deletedCount);
+
+        log.info("Update completed for request {}. Added: {}, Deleted: {}, Final Count: {}",
+                requestId, addedCount, deletedCount, finalImages.size());
+        return UpdateGenerationResponse.from(generationRequest, imageSummary);
+    }
+}

--- a/backend-spring/today-store/src/main/resources/db/migration/V2__add_target_fields_to_generation_requests.sql
+++ b/backend-spring/today-store/src/main/resources/db/migration/V2__add_target_fields_to_generation_requests.sql
@@ -1,0 +1,7 @@
+-- V2__add_target_fields_to_generation_requests.sql
+
+ALTER TABLE generation_requests ADD COLUMN target_age VARCHAR(50);
+ALTER TABLE generation_requests ADD COLUMN target_gender VARCHAR(20);
+
+COMMENT ON COLUMN generation_requests.target_age IS '타겟 연령대 (예: 20대, 3040 등)';
+COMMENT ON COLUMN generation_requests.target_gender IS '타겟 성별';

--- a/backend-spring/today-store/src/main/resources/db/migration/V3__add_updated_at_field_to_generation_requests.sql
+++ b/backend-spring/today-store/src/main/resources/db/migration/V3__add_updated_at_field_to_generation_requests.sql
@@ -1,0 +1,9 @@
+-- V3__add_updated_at_field_to_generation_requests.sql
+
+-- updated_at 컬럼 추가 (기본값 현재 시간)
+ALTER TABLE generation_requests ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- 기존 데이터의 updated_at을 created_at과 동일하게 설정
+UPDATE generation_requests SET updated_at = created_at;
+
+COMMENT ON COLUMN generation_requests.updated_at IS '수정 일시';


### PR DESCRIPTION
## Issue Number
closed #26 

## As-Is
- 사용자가 AI 컨텐츠 생성을 위해 입력하는 생성 요청 정보 관리 API 필요함
- 이미지 데이터 관리를 위해 GCS 연동 모둘(서비스)가 필요함
- 에러 코드 중 메시지가 겹치는 코드가 있어 구별이 어려움

## To-Be
- `common/gcs/GcsService.java` : 이미지 데이터 관리(저장, 삭제, signed url 생성)를 위한 gcs 연동 서비스 클래스
- 에러 핸들링 업데이트 : `A008`, `C001`, `C002`, `C003`, `C004`, `C005` 에러코드 추가 및 `ValidationErrorResolver`에서 C001 에러 처리 추가, `GlobalExceptionHandler` 에서 `C004` 에러 핸들링 추가.
- 생성 요청 정보 관리 API 추가
    1. POST /api/v1/request : 새로운 생성 요청 추가
    2. GET /api/v1/request/{requestId} : Generation Request 단건 조회
    3. GET /api/v1/requests : 인증된 사용자의 Generation Request 목록 조회(paged)
    4. PATCH /api/v1/request/{requestId} : 대상 Generation Request 내용 수정
    5. DELETE /api/v1/request/{requestId} : 대상 Generation Requset 삭제 (soft delete)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- API response example이 추가된 postman collecton json을 Notion Wiki "API 엔드포인트" 문서에 업데이트함.
- PATCH /api/v1/request/{requestId} 엔드포인트 : request body에서 `deletedImageIds` 필드 제거(기존 설계 내용에서 변경됨). 
- A008 에러 코드의 메시지가 A006과 동일하여 A008 에러 메시지 변경(`Access Denied` -> `Access denied. Resource ownership mismatch.`)
- 기존 설계에서 변경된 사항은 Notion Wiki "API 엔드포인트" 문서에 업데이트함(A008 에러 메시지, updateGenerationRequset reqeust body).
