### PR TITLE
[Build] Trivy 보안 이슈 대응을 위한 Backend CI/CD 수정

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -128,10 +128,10 @@ jobs:
 
       # Scan Docker image for HIGH/CRITICAL vulnerabilities
       - name: Trivy security scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ${{ steps.image_meta.outputs.image_uri }}
-          version: v0.69.2
+          version: v0.69.3
           format: table
           vuln-type: 'os,library'
           severity: 'HIGH,CRITICAL'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -52,10 +52,10 @@ jobs:
 
       # Scan Docker image for HIGH/CRITICAL vulnerabilities
       - name: Trivy security scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: backend-ci-test:latest
-          version: v0.69.2
+          version: v0.69.3
           format: table
           vuln-type: 'os,library'
           severity: 'HIGH,CRITICAL'


### PR DESCRIPTION
## Issue Number
closed #28 

## As-Is
- backend CI/CD에서 사용하는 Trivy action이 보안 이슈 대응이 필요
- Trivy action이 mutable reference 기반으로 사용되고 있어 공급망 보안 측면에서 리스크가 존재

## To-Be
- Trivy 보안 이슈 대응을 위해 backend CI/CD의 Trivy action을 안전한 버전으로 수정
- Trivy action에 full SHA pinning을 적용해 immutable reference 기반으로 실행되도록 변경
- backend workflow의 Trivy 스캔 단계가 보다 안전하게 동작하도록 정리

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- Trivy advisory 기준 공격 노출 시간대는 KST 기준 2026-03-20 02:43 ~ 14:40 입니다.
- Backend CI/CD 실행 이력 및 rerun 상세 내역을 확인한 결과, 해당 시간대와 겹치는 run은 확인되지 않았습니다.
- 따라서 현재 확인 가능한 Backend CI/CD 기록 기준으로는 이번 Trivy 공급망 공격의 영향을 받지 않은 것으로 판단했습니다.