### PR TITLE
Fix/backend gcs path and ratelimit

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-storage'
 	implementation 'com.bucket4j:bucket4j-core:8.10.1'
+	implementation 'com.bucket4j:bucket4j-redis:8.10.1'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
@@ -11,6 +11,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -25,8 +27,13 @@ public class GcsService {
     private String bucketName;
 
     public String uploadFile(MultipartFile file, String folder) {
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+
         String uuid = UUID.randomUUID().toString();
-        String objectName = folder + "/" + uuid + "_" + file.getOriginalFilename();
+
+        String objectName = String.format("%s/%s/%s_%s",
+                datePath, folder, uuid, file.getOriginalFilename());
+
         try {
             BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName)
                     .setContentType(file.getContentType())

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitConfig.java
@@ -1,0 +1,43 @@
+package today_store.common.ratelimit;
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ClientSideConfig;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.lettuce.cas.LettuceBasedProxyManager;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+public class RateLimitConfig {
+
+    @Bean
+    public ProxyManager<String> proxyManager(RedisConnectionFactory redisConnectionFactory) {
+        if (!(redisConnectionFactory instanceof LettuceConnectionFactory lettuceConnectionFactory)) {
+            throw new IllegalStateException("LettuceConnectionFactory is required");
+        }
+
+        RedisClient redisClient = (RedisClient) lettuceConnectionFactory.getNativeClient();
+        if (redisClient == null) {
+            throw new IllegalStateException("RedisClient is not available from LettuceConnectionFactory");
+        }
+
+        StatefulRedisConnection<String, byte[]> connection = redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
+        ExpirationAfterWriteStrategy expirationStrategy = ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(Duration.ofMinutes(1));
+
+        return LettuceBasedProxyManager.builderFor(connection)
+                .withClientSideConfig(
+                        ClientSideConfig.getDefault()
+                                .withExpirationAfterWriteStrategy(expirationStrategy)
+                )
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
@@ -3,14 +3,11 @@ package today_store.common.ratelimit;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.BucketConfiguration;
-import io.github.bucket4j.Refill;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 @Slf4j

--- a/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/ratelimit/RateLimitService.java
@@ -2,23 +2,30 @@ package today_store.common.ratelimit;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
 import io.github.bucket4j.Refill;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class RateLimitService {
 
-    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+    private final ProxyManager<String> proxyManager;
 
     public boolean tryConsume(String key, RateLimitTier tier) {
-        String bucketKey = key + ":" + tier.name();
-        Bucket bucket = buckets.computeIfAbsent(bucketKey, k -> createNewBucket(tier));
-        
+        String bucketKey = "ratelimit:" + key + ":" + tier.name();
+
+        Supplier<BucketConfiguration> configurationSupplier = () -> createBucketConfiguration(tier);
+        Bucket bucket = proxyManager.builder().build(bucketKey, configurationSupplier);
+
         boolean allowed = bucket.tryConsume(1);
         if (!allowed) {
             log.warn("Rate limit exceeded for key: {} (Tier: {})", key, tier.name());
@@ -26,13 +33,13 @@ public class RateLimitService {
         return allowed;
     }
 
-    private Bucket createNewBucket(RateLimitTier tier) {
+    private BucketConfiguration createBucketConfiguration(RateLimitTier tier) {
         Bandwidth limit = Bandwidth.builder()
                 .capacity(tier.getCapacity())
                 .refillIntervally(tier.getCapacity(), tier.getDuration())
                 .build();
 
-        return Bucket.builder()
+        return BucketConfiguration.builder()
                 .addLimit(limit)
                 .build();
     }

--- a/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
@@ -70,7 +70,7 @@ public class GenerationRequestService {
             String description = request.getImageDescriptions().get(i);
 
             log.debug("Uploading image {}/{} for request ID: {}", (i + 1), request.getImages().size(), savedRequest.getId());
-            String url = gcsService.uploadFile(imageFile, "requests/" + savedRequest.getId());
+            String url = gcsService.uploadFile(imageFile, "requests");
 
             InputImage inputImage = InputImage.builder()
                     .generationRequest(savedRequest)
@@ -237,7 +237,7 @@ public class GenerationRequestService {
                         log.warn("File name mismatch during update: {}", config.getFileName());
                         throw new FileNameMismatchException();
                     }
-                    String url = gcsService.uploadFile(file, "requests/" + requestId);
+                    String url = gcsService.uploadFile(file, "requests");
                     InputImage newImg = InputImage.builder()
                             .generationRequest(generationRequest)
                             .url(url)

--- a/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/request/service/GenerationRequestService.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/backend-spring/today-store/src/test/java/today_store/TodayStoreApplicationTests.java
+++ b/backend-spring/today-store/src/test/java/today_store/TodayStoreApplicationTests.java
@@ -1,6 +1,7 @@
 package today_store;
 
 import com.google.cloud.storage.Storage;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -10,6 +11,9 @@ class TodayStoreApplicationTests {
 
 	@MockitoBean
 	private Storage storage;
+
+	@MockitoBean
+	private ProxyManager<String> proxyManager;
 
 	@Test
 	void contextLoads() {

--- a/backend-spring/today-store/src/test/java/today_store/common/ratelimit/RateLimitServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/ratelimit/RateLimitServiceTest.java
@@ -1,14 +1,49 @@
 package today_store.common.ratelimit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.distributed.proxy.RemoteBucketBuilder;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("RateLimit 서비스 테스트")
 class RateLimitServiceTest {
 
-    private final RateLimitService rateLimitService = new RateLimitService();
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+    private final ProxyManager<String> proxyManager = mock(ProxyManager.class);
+    private final RateLimitService rateLimitService = new RateLimitService(proxyManager);
+
+@BeforeEach
+void setUp() {
+    RemoteBucketBuilder<String> builder = mock(RemoteBucketBuilder.class);
+    when(proxyManager.builder()).thenReturn(builder);
+
+    when(builder.build(anyString(), any(Supplier.class))).thenAnswer(invocation -> {
+        String key = invocation.getArgument(0);
+        Supplier<BucketConfiguration> configSupplier = invocation.getArgument(1);
+
+        return (io.github.bucket4j.distributed.BucketProxy) buckets.computeIfAbsent(key, k -> {
+            BucketConfiguration config = configSupplier.get();
+            Bucket localBucket = Bucket.builder()
+                    .addLimit(config.getBandwidths()[0])
+                    .build();
+
+            io.github.bucket4j.distributed.BucketProxy proxy = mock(io.github.bucket4j.distributed.BucketProxy.class);
+            when(proxy.tryConsume(anyLong())).thenAnswer(inv -> localBucket.tryConsume((Long) inv.getArgument(0)));
+            return (Bucket) proxy;
+        });
+    });
+}
 
     @Test
     @DisplayName("같은 키와 티어는 용량만큼만 허용")


### PR DESCRIPTION
## Issue Number
closed #35 

## As-Is
- 현재 rate limit 구현이 Concurrent HashMap 기반으로 구현되어 cloud run 분산 환경에서 정책이 제대로 반영되지 않을 수 있음. 
- GCS 파일 저장 경로가 `requests/{GENERATION_REQUEST_UUID}/{IMAGE_UUID}_{FILE_NAME}`와 같은 형태로 저장되어 날짜 별로 파일을 관리하는데 어려움.

## To-Be
- `bucket4j-redis` 의존성 추가
- redis client 연동을 위한 proxy manager Bean 클래스 추가
- Rate Limit Service에서 Concurrent HashMap 방식 제거, redis(proxy manager) 기반 방식으로 변경
- `GcsService.uploadFile` 메서드의 파일 저장 경로를 `YYYY/MM/DD/requests/{IMAGE_UUID}_{FILE_NAME}`으로 변경
- `GenerationRequestService` 클래스에서 uploadFile 메서드 호출 부의 `folder` argument 값 변경( -> "requests")

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- Rate Limit 구현 방식 변경으로 `RateLimitServiceTest.java` 테스트 코드 수정
- 
