### PR TITLE
[Test] 생성 요청 관리 API 테스트 코드 작성

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.10'
+	id 'org.springframework.boot' version '3.5.13'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/backend-spring/today-store/src/test/java/today_store/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/exception/GlobalExceptionHandlerTest.java
@@ -11,9 +11,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import today_store.authentication.dto.LoginRequest;
+import today_store.authentication.exception.AccessDeniedToResourceException;
 import today_store.authentication.exception.InvalidRefreshTokenException;
+import today_store.common.dto.PageRequest;
 import today_store.common.dto.ErrorResponse;
+import today_store.content.request.dto.CreateGenerationRequest;
+import today_store.content.request.dto.UpdateGenerationRequest;
+import today_store.content.request.exception.FileNameMismatchException;
+import today_store.content.request.exception.GenerationRequestNotFoundException;
+import today_store.content.request.exception.InvalidRequestBodyFormatException;
 
 @DisplayName("전역 예외 처리기 테스트")
 class GlobalExceptionHandlerTest {
@@ -89,9 +97,210 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getErrors().get(0).getReason()).isEqualTo("소셜 로그인 제공자(provider)는 필수 항목입니다.");
     }
 
+    @Test
+    @DisplayName("생성 요청 검증 실패를 C001 응답으로 변환")
+    void shouldHandleCreateGenerationValidationException() throws Exception {
+        // 생성 요청 검증 실패는 C001 에러 응답으로 변환해야 한다.
+
+        // given
+        Method method = ValidationFixture.class.getDeclaredMethod("handleCreateGeneration", CreateGenerationRequest.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
+                CreateGenerationRequest.builder().build(),
+                "createGenerationRequest"
+        );
+        bindingResult.addError(new FieldError(
+                "createGenerationRequest",
+                "concept",
+                null,
+                false,
+                null,
+                null,
+                "Concept is required"
+        ));
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMethodArgumentNotValidException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C001");
+        assertThat(response.getBody().getMessage()).isEqualTo("Missing required fields");
+        assertThat(response.getBody().getErrors()).hasSize(1);
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("concept");
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 검증 실패를 C001 응답으로 변환")
+    void shouldHandleUpdateGenerationValidationException() throws Exception {
+        // 생성 요청 수정 검증 실패는 C001 에러 응답으로 변환해야 한다.
+
+        // given
+        Method method = ValidationFixture.class.getDeclaredMethod("handleUpdateGeneration", UpdateGenerationRequest.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
+                UpdateGenerationRequest.builder().build(),
+                "updateGenerationRequest"
+        );
+        bindingResult.addError(new FieldError(
+                "updateGenerationRequest",
+                "imageConfigs",
+                "",
+                false,
+                null,
+                null,
+                "imageConfigs are required"
+        ));
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMethodArgumentNotValidException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C001");
+        assertThat(response.getBody().getMessage()).isEqualTo("Missing required fields");
+        assertThat(response.getBody().getErrors()).hasSize(1);
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("imageConfigs");
+    }
+
+    @Test
+    @DisplayName("페이지 검증 실패를 P001 응답으로 변환")
+    void shouldHandlePageRequestValidationException() throws Exception {
+        // 페이지 파라미터 검증 실패는 P001 에러 응답으로 변환해야 한다.
+
+        // given
+        Method method = ValidationFixture.class.getDeclaredMethod("handlePageRequest", PageRequest.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new PageRequest(), "pageRequest");
+        bindingResult.addError(new FieldError(
+                "pageRequest",
+                "page",
+                "0",
+                false,
+                null,
+                null,
+                "Page number should be greater than 1"
+        ));
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMethodArgumentNotValidException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("P001");
+        assertThat(response.getBody().getMessage()).isEqualTo("invalid (page, size) parameter");
+        assertThat(response.getBody().getErrors()).hasSize(1);
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("page");
+    }
+
+    @Test
+    @DisplayName("파일 크기 초과를 C004 응답으로 변환")
+    void shouldHandleMaxUploadSizeExceededException() {
+        // 업로드 파일 크기 초과는 C004 에러 응답으로 변환해야 한다.
+
+        // given
+        MaxUploadSizeExceededException exception = new MaxUploadSizeExceededException(10L);
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMaxUploadSizeExceededException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(413);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C004");
+        assertThat(response.getBody().getMessage()).isEqualTo("File size limit exceeded");
+    }
+
+    @Test
+    @DisplayName("파일명 불일치를 C002 응답으로 변환")
+    void shouldHandleFileNameMismatchException() {
+        // 파일명 불일치 예외는 C002 에러 응답으로 변환해야 한다.
+
+        // given
+        FileNameMismatchException exception = new FileNameMismatchException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C002");
+        assertThat(response.getBody().getMessage()).isEqualTo("File name mismatch in imageConfigs");
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 본문 형식을 C003 응답으로 변환")
+    void shouldHandleInvalidRequestBodyFormatException() {
+        // 잘못된 요청 본문 형식 예외는 C003 에러 응답으로 변환해야 한다.
+
+        // given
+        InvalidRequestBodyFormatException exception = new InvalidRequestBodyFormatException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C003");
+        assertThat(response.getBody().getMessage()).isEqualTo("Invalid request body format");
+    }
+
+    @Test
+    @DisplayName("생성 요청 없음 예외를 C005 응답으로 변환")
+    void shouldHandleGenerationRequestNotFoundException() {
+        // 생성 요청이 없으면 C005 에러 응답으로 변환해야 한다.
+
+        // given
+        GenerationRequestNotFoundException exception = new GenerationRequestNotFoundException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C005");
+        assertThat(response.getBody().getMessage()).isEqualTo("Request not found or already deleted");
+    }
+
+    @Test
+    @DisplayName("리소스 소유권 불일치를 A008 응답으로 변환")
+    void shouldHandleAccessDeniedToResourceException() {
+        // 리소스 소유권 불일치 예외는 A008 에러 응답으로 변환해야 한다.
+
+        // given
+        AccessDeniedToResourceException exception = new AccessDeniedToResourceException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(403);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("A008");
+        assertThat(response.getBody().getMessage()).isEqualTo("Access denied. Resource ownership mismatch.");
+    }
+
     private static class ValidationFixture {
 
         public void handle(@Valid LoginRequest loginRequest) {
+        }
+
+        public void handleCreateGeneration(@Valid CreateGenerationRequest createGenerationRequest) {
+        }
+
+        public void handleUpdateGeneration(@Valid UpdateGenerationRequest updateGenerationRequest) {
+        }
+
+        public void handlePageRequest(@Valid PageRequest pageRequest) {
         }
     }
 }

--- a/backend-spring/today-store/src/test/java/today_store/common/gcs/GcsServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/gcs/GcsServiceTest.java
@@ -1,0 +1,173 @@
+package today_store.common.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GCS 서비스 테스트")
+class GcsServiceTest {
+
+    @Mock
+    private Storage storage;
+
+    private GcsService gcsService;
+
+    @BeforeEach
+    void setUp() {
+        gcsService = new GcsService(storage);
+        ReflectionTestUtils.setField(gcsService, "bucketName", "test-bucket");
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 성공")
+    void shouldUploadFileToGcs() throws Exception {
+        // 업로드 요청이 오면 bucket, object name, content type을 반영해 storage.create를 호출해야 한다.
+
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "images",
+                "sample.png",
+                "image/png",
+                "image-data".getBytes(StandardCharsets.UTF_8)
+        );
+        given(storage.create(any(BlobInfo.class), any(byte[].class))).willReturn(null);
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+
+        // when
+        String objectName = gcsService.uploadFile(file, "requests");
+
+        // then
+        assertThat(objectName).matches("^" + datePath + "/requests/[0-9a-f\\-]+_sample\\.png$");
+
+        ArgumentCaptor<BlobInfo> blobInfoCaptor = ArgumentCaptor.forClass(BlobInfo.class);
+        ArgumentCaptor<byte[]> bytesCaptor = ArgumentCaptor.forClass(byte[].class);
+        then(storage).should().create(blobInfoCaptor.capture(), bytesCaptor.capture());
+        assertThat(blobInfoCaptor.getValue().getBucket()).isEqualTo("test-bucket");
+        assertThat(blobInfoCaptor.getValue().getName()).isEqualTo(objectName);
+        assertThat(blobInfoCaptor.getValue().getContentType()).isEqualTo("image/png");
+        assertThat(bytesCaptor.getValue()).containsExactly("image-data".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패")
+    void shouldThrowWhenUploadFails() throws Exception {
+        // 파일 바이트를 읽지 못하면 GCS 업로드 실패 런타임 예외로 감싸야 한다.
+
+        // given
+        org.springframework.web.multipart.MultipartFile file = org.mockito.Mockito.mock(org.springframework.web.multipart.MultipartFile.class);
+        given(file.getOriginalFilename()).willReturn("sample.png");
+        given(file.getContentType()).willReturn("image/png");
+        given(file.getBytes()).willThrow(new IOException("read failed"));
+
+        // when
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> gcsService.uploadFile(file, "requests")
+        );
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("GCS upload failed");
+        assertThat(exception.getCause()).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    @DisplayName("Signed URL 생성 성공")
+    void shouldGenerateSignedUrl() throws Exception {
+        // objectName이 있으면 storage.signUrl로 signed URL 문자열을 생성해야 한다.
+
+        // given
+        URL signedUrl = new URL("https://signed.example.com/image");
+        given(storage.signUrl(any(BlobInfo.class), eq(15L), eq(TimeUnit.MINUTES), any(Storage.SignUrlOption[].class)))
+                .willReturn(signedUrl);
+
+        // when
+        String result = gcsService.generateSignedUrl("2026/03/30/requests/sample.png");
+
+        // then
+        assertThat(result).isEqualTo("https://signed.example.com/image");
+
+        ArgumentCaptor<BlobInfo> blobInfoCaptor = ArgumentCaptor.forClass(BlobInfo.class);
+        then(storage).should().signUrl(
+                blobInfoCaptor.capture(),
+                eq(15L),
+                eq(TimeUnit.MINUTES),
+                any(Storage.SignUrlOption[].class)
+        );
+        assertThat(blobInfoCaptor.getValue().getBlobId().getBucket()).isEqualTo("test-bucket");
+        assertThat(blobInfoCaptor.getValue().getBlobId().getName()).isEqualTo("2026/03/30/requests/sample.png");
+    }
+
+    @Test
+    @DisplayName("Signed URL 생성 입력값 비어 있음")
+    void shouldReturnNullWhenObjectNameIsBlankForSignedUrl() {
+        // objectName이 null 또는 빈 문자열이면 signed URL 생성 없이 null을 반환해야 한다.
+
+        // given
+
+        // when
+        String nullResult = gcsService.generateSignedUrl(null);
+        String blankResult = gcsService.generateSignedUrl("");
+
+        // then
+        assertThat(nullResult).isNull();
+        assertThat(blankResult).isNull();
+        then(storage).should(never()).signUrl(any(BlobInfo.class), eq(15L), eq(TimeUnit.MINUTES), any(Storage.SignUrlOption[].class));
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 성공")
+    void shouldDeleteSanitizedObjectName() {
+        // objectName이 있으면 sanitize 후 storage.delete를 호출해야 한다.
+
+        // given
+        given(storage.delete(any(BlobId.class))).willReturn(true);
+
+        // when
+        gcsService.deleteFile("folder/\nfile.png");
+
+        // then
+        ArgumentCaptor<BlobId> blobIdCaptor = ArgumentCaptor.forClass(BlobId.class);
+        then(storage).should().delete(blobIdCaptor.capture());
+        assertThat(blobIdCaptor.getValue().getBucket()).isEqualTo("test-bucket");
+        assertThat(blobIdCaptor.getValue().getName()).isEqualTo("folder/ file.png");
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 입력값 비어 있음")
+    void shouldSkipDeleteWhenObjectNameIsBlank() {
+        // objectName이 null 또는 빈 문자열이면 삭제를 시도하지 않아야 한다.
+
+        // given
+
+        // when
+        gcsService.deleteFile(null);
+        gcsService.deleteFile("");
+
+        // then
+        then(storage).should(never()).delete(any(BlobId.class));
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/request/controller/GenerationRequestControllerWebMvcTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/request/controller/GenerationRequestControllerWebMvcTest.java
@@ -1,0 +1,532 @@
+package today_store.content.request.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import today_store.authentication.entity.User;
+import today_store.common.exception.ValidationErrorResolver;
+import today_store.common.ratelimit.RateLimitService;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.content.request.dto.CreateGenerationResponse;
+import today_store.content.request.dto.GenerationRequestDetailResponse;
+import today_store.content.request.dto.GenerationRequestListResponse;
+import today_store.content.request.dto.UpdateGenerationResponse;
+import today_store.content.request.service.GenerationRequestService;
+import today_store.user.service.UserService;
+
+@WebMvcTest(controllers = GenerationRequestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ValidationErrorResolver.class)
+@DisplayName("생성 요청 컨트롤러 테스트")
+class GenerationRequestControllerWebMvcTest {
+
+    private static final String CLIENT_IP = "203.0.113.30";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GenerationRequestService generationRequestService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @BeforeEach
+    void setUp() {
+        given(rateLimitService.tryConsume(anyString(), any(RateLimitTier.class))).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("생성 요청 생성 성공")
+    void shouldCreateGenerationRequest() throws Exception {
+        // 멀티파트 생성 요청이 들어오면 201 응답과 생성 정보를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 30, 18, 0);
+        MockMultipartFile image = createMultipartFile("images", "first.png", "first-image");
+        CreateGenerationResponse response = CreateGenerationResponse.builder()
+                .requestId(requestId)
+                .createdAt(createdAt)
+                .build();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(generationRequestService.createRequest(eq(user), any())).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request")
+                        .file(image)
+                        .param("concept", "봄 프로모션")
+                        .param("additionalNote", "따뜻한 분위기")
+                        .param("targetAge", "20대")
+                        .param("targetGender", "여성")
+                        .param("imageDescriptions", "정면 이미지")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(201);
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(LocalDateTime.parse(body.get("createdAt").asText())).isEqualTo(createdAt);
+        then(userService).should().getUser(any(Authentication.class));
+        then(generationRequestService).should().createRequest(
+                eq(user),
+                argThat(request ->
+                        request.getConcept().equals("봄 프로모션")
+                                && request.getAdditionalNote().equals("따뜻한 분위기")
+                                && request.getTargetAge().equals("20대")
+                                && request.getTargetGender().equals("여성")
+                                && request.getImageDescriptions().equals(List.of("정면 이미지"))
+                                && request.getImages().size() == 1
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("생성 요청 목록 조회 성공")
+    void shouldReturnGenerationRequestList() throws Exception {
+        // 인증된 사용자가 요청 목록을 조회하면 목록과 페이징 정보를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 30, 18, 10);
+        LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 18, 20);
+        GenerationRequestListResponse response = GenerationRequestListResponse.builder()
+                .data(List.of(
+                        GenerationRequestListResponse.GenerationRequestSummary.builder()
+                                .requestId(requestId)
+                                .concept("봄 프로모션")
+                                .thumbnailUrl("https://signed.example.com/thumb")
+                                .imageCount(2)
+                                .createdAt(createdAt)
+                                .updatedAt(updatedAt)
+                                .build()
+                ))
+                .pagination(GenerationRequestListResponse.PaginationInfo.builder()
+                        .currentPage(1)
+                        .pageSize(10)
+                        .totalCount(1L)
+                        .totalPages(1)
+                        .hasNext(false)
+                        .hasPrevious(false)
+                        .build())
+                .build();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(generationRequestService.getRequests(eq(user), any())).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/requests")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("data").size()).isEqualTo(1);
+        assertThat(body.get("data").get(0).get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("data").get(0).get("concept").asText()).isEqualTo("봄 프로모션");
+        assertThat(body.get("data").get(0).get("thumbnailUrl").asText()).isEqualTo("https://signed.example.com/thumb");
+        assertThat(body.get("data").get(0).get("imageCount").asInt()).isEqualTo(2);
+        assertThat(LocalDateTime.parse(body.get("data").get(0).get("createdAt").asText())).isEqualTo(createdAt);
+        assertThat(LocalDateTime.parse(body.get("data").get(0).get("updatedAt").asText())).isEqualTo(updatedAt);
+        assertThat(body.get("pagination").get("currentPage").asInt()).isEqualTo(1);
+        assertThat(body.get("pagination").get("pageSize").asInt()).isEqualTo(10);
+        assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(1L);
+        assertThat(body.get("pagination").get("totalPages").asInt()).isEqualTo(1);
+        assertThat(body.get("pagination").get("hasNext").asBoolean()).isFalse();
+        assertThat(body.get("pagination").get("hasPrevious").asBoolean()).isFalse();
+        then(generationRequestService).should().getRequests(
+                eq(user),
+                argThat(pageable -> pageable.getPageNumber() == 0 && pageable.getPageSize() == 10)
+        );
+    }
+
+    @Test
+    @DisplayName("생성 요청 상세 조회 성공")
+    void shouldReturnGenerationRequestDetail() throws Exception {
+        // 인증된 사용자가 요청 상세를 조회하면 이미지 포함 상세 정보를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID imageId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 30, 18, 30);
+        LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 18, 40);
+        LocalDateTime imageCreatedAt = LocalDateTime.of(2026, 3, 30, 18, 31);
+        GenerationRequestDetailResponse response = GenerationRequestDetailResponse.builder()
+                .id(requestId)
+                .userId(user.getId())
+                .concept("봄 프로모션")
+                .additionalNote("따뜻한 분위기")
+                .targetAge("20대")
+                .targetGender("여성")
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .images(List.of(
+                        GenerationRequestDetailResponse.ImageResponse.builder()
+                                .id(imageId)
+                                .url("https://signed.example.com/image")
+                                .description("정면 이미지")
+                                .displayOrder(1)
+                                .createdAt(imageCreatedAt)
+                                .build()
+                ))
+                .build();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(generationRequestService.getRequestDetail(user, requestId)).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/request/{requestId}", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("id").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("userId").asText()).isEqualTo(user.getId().toString());
+        assertThat(body.get("concept").asText()).isEqualTo("봄 프로모션");
+        assertThat(body.get("images").size()).isEqualTo(1);
+        assertThat(body.get("images").get(0).get("id").asText()).isEqualTo(imageId.toString());
+        assertThat(body.get("images").get(0).get("url").asText()).isEqualTo("https://signed.example.com/image");
+        assertThat(body.get("images").get(0).get("description").asText()).isEqualTo("정면 이미지");
+        assertThat(body.get("images").get(0).get("displayOrder").asInt()).isEqualTo(1);
+        assertThat(LocalDateTime.parse(body.get("createdAt").asText())).isEqualTo(createdAt);
+        assertThat(LocalDateTime.parse(body.get("updatedAt").asText())).isEqualTo(updatedAt);
+        assertThat(LocalDateTime.parse(body.get("images").get(0).get("createdAt").asText())).isEqualTo(imageCreatedAt);
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 성공")
+    void shouldUpdateGenerationRequest() throws Exception {
+        // deletedImageIds 없이 imageConfigs만 전달해 수정 응답을 반환해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 18, 50);
+        String imageConfigs = """
+                [
+                  {"id":"%s","description":"수정된 설명","displayOrder":1},
+                  {"fileName":"new-image.png","description":"신규 이미지","displayOrder":2}
+                ]
+                """.formatted(UUID.randomUUID());
+        MockMultipartFile newImage = createMultipartFile("newImages", "new-image.png", "new-image");
+        UpdateGenerationResponse response = UpdateGenerationResponse.builder()
+                .requestId(requestId)
+                .concept("수정된 컨셉")
+                .additionalNote("수정된 메모")
+                .targetAge("20대")
+                .targetGender("여성")
+                .updatedAt(updatedAt)
+                .imageSummary(UpdateGenerationResponse.ImageSummary.builder()
+                        .totalCount(2)
+                        .addedCount(1)
+                        .deletedCount(1)
+                        .build())
+                .build();
+        given(generationRequestService.updateRequest(eq("user@example.com"), eq(requestId), any())).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request/{requestId}", requestId)
+                        .file(newImage)
+                        .param("concept", "수정된 컨셉")
+                        .param("additionalNote", "수정된 메모")
+                        .param("targetAge", "20대")
+                        .param("targetGender", "여성")
+                        .param("imageConfigs", imageConfigs)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken())
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        }))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("concept").asText()).isEqualTo("수정된 컨셉");
+        assertThat(body.get("additionalNote").asText()).isEqualTo("수정된 메모");
+        assertThat(body.get("imageSummary").get("totalCount").asInt()).isEqualTo(2);
+        assertThat(body.get("imageSummary").get("addedCount").asInt()).isEqualTo(1);
+        assertThat(body.get("imageSummary").get("deletedCount").asInt()).isEqualTo(1);
+        assertThat(LocalDateTime.parse(body.get("updatedAt").asText())).isEqualTo(updatedAt);
+        then(generationRequestService).should().updateRequest(
+                eq("user@example.com"),
+                eq(requestId),
+                argThat(request ->
+                        request.getConcept().equals("수정된 컨셉")
+                                && request.getAdditionalNote().equals("수정된 메모")
+                                && request.getTargetAge().equals("20대")
+                                && request.getTargetGender().equals("여성")
+                                && request.getImageConfigs().equals(imageConfigs)
+                                && request.getNewImages().size() == 1
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("생성 요청 삭제 성공")
+    void shouldDeleteGenerationRequest() throws Exception {
+        // 인증된 사용자가 요청을 삭제하면 204 응답을 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+
+        // when
+        MvcResult result = mockMvc.perform(delete("/api/v1/contents/request/{requestId}", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(204);
+        assertThat(result.getResponse().getContentAsString()).isBlank();
+        then(userService).should().getUser(any(Authentication.class));
+        then(generationRequestService).should().deleteRequest(user, requestId);
+    }
+
+    @Test
+    @DisplayName("생성 요청 생성 검증 오류")
+    void shouldReturnBadRequestWhenCreateRequestIsInvalid() throws Exception {
+        // 필수 입력 없이 생성 요청하면 C001 검증 에러를 반환해야 한다.
+
+        // given
+        MockMultipartFile image = createMultipartFile("images", "first.png", "first-image");
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request")
+                        .file(image)
+                        .param("imageDescriptions", "정면 이미지")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("C001");
+        assertThat(body.get("errors").size()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 검증 오류")
+    void shouldReturnBadRequestWhenUpdateRequestIsInvalid() throws Exception {
+        // imageConfigs가 비어 있으면 C001 검증 에러를 반환해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request/{requestId}", requestId)
+                        .param("concept", "수정된 컨셉")
+                        .param("imageConfigs", "")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken())
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        }))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("C001");
+        assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("imageConfigs");
+    }
+
+    @Test
+    @DisplayName("생성 요청 목록 페이징 검증 오류")
+    void shouldReturnBadRequestWhenPageRequestIsInvalid() throws Exception {
+        // 잘못된 page, size 값이면 P001 검증 에러를 반환해야 한다.
+
+        // given
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/requests")
+                        .param("page", "0")
+                        .param("size", "101")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("P001");
+        assertThat(body.get("errors").size()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("생성 요청 생성 요청 제한")
+    void shouldReturnTooManyRequestsWhenCreateRequestRateLimitIsExceeded() throws Exception {
+        // 생성 요청 엔드포인트는 MIDDLE 티어 레이트리밋을 적용해야 한다.
+
+        // given
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.MIDDLE)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request")
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(body.get("code").asText()).isEqualTo("R001");
+        then(rateLimitService).should().tryConsume(CLIENT_IP, RateLimitTier.MIDDLE);
+    }
+
+    @Test
+    @DisplayName("생성 요청 목록 조회 요청 제한")
+    void shouldReturnTooManyRequestsWhenListRequestRateLimitIsExceeded() throws Exception {
+        // 목록 조회 엔드포인트는 LOW 티어 레이트리밋을 적용해야 한다.
+
+        // given
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.LOW)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/requests")
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(body.get("code").asText()).isEqualTo("R001");
+        then(rateLimitService).should().tryConsume(CLIENT_IP, RateLimitTier.LOW);
+    }
+
+    @Test
+    @DisplayName("생성 요청 상세 조회 요청 제한")
+    void shouldReturnTooManyRequestsWhenDetailRequestRateLimitIsExceeded() throws Exception {
+        // 상세 조회 엔드포인트는 LOW 티어 레이트리밋을 적용해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.LOW)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/request/{requestId}", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(body.get("code").asText()).isEqualTo("R001");
+        then(rateLimitService).should().tryConsume(CLIENT_IP, RateLimitTier.LOW);
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 요청 제한")
+    void shouldReturnTooManyRequestsWhenUpdateRequestRateLimitIsExceeded() throws Exception {
+        // 수정 엔드포인트는 MIDDLE 티어 레이트리밋을 적용해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.MIDDLE)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(multipart("/api/v1/contents/request/{requestId}", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        }))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(body.get("code").asText()).isEqualTo("R001");
+        then(rateLimitService).should().tryConsume(CLIENT_IP, RateLimitTier.MIDDLE);
+    }
+
+    @Test
+    @DisplayName("생성 요청 삭제 요청 제한")
+    void shouldReturnTooManyRequestsWhenDeleteRequestRateLimitIsExceeded() throws Exception {
+        // 삭제 엔드포인트는 MIDDLE 티어 레이트리밋을 적용해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.MIDDLE)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(delete("/api/v1/contents/request/{requestId}", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(body.get("code").asText()).isEqualTo("R001");
+        then(rateLimitService).should().tryConsume(CLIENT_IP, RateLimitTier.MIDDLE);
+    }
+
+    private JsonNode readBody(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken() {
+        return new UsernamePasswordAuthenticationToken(
+                "user@example.com",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private User createUser(String email) {
+        User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
+        org.springframework.test.util.ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        return user;
+    }
+
+    private MockMultipartFile createMultipartFile(String parameterName, String originalFilename, String content) {
+        return new MockMultipartFile(parameterName, originalFilename, "image/png", content.getBytes());
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/request/service/GenerationRequestServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/request/service/GenerationRequestServiceTest.java
@@ -1,0 +1,851 @@
+package today_store.content.request.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import today_store.authentication.entity.User;
+import today_store.authentication.exception.AccessDeniedToResourceException;
+import today_store.authentication.exception.UserNotFoundException;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gcs.GcsService;
+import today_store.content.request.dto.CreateGenerationRequest;
+import today_store.content.request.dto.CreateGenerationResponse;
+import today_store.content.request.dto.GenerationRequestDetailResponse;
+import today_store.content.request.dto.GenerationRequestListResponse;
+import today_store.content.request.dto.ImageConfig;
+import today_store.content.request.dto.UpdateGenerationRequest;
+import today_store.content.request.dto.UpdateGenerationResponse;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+import today_store.content.request.exception.FileNameMismatchException;
+import today_store.content.request.exception.GenerationRequestNotFoundException;
+import today_store.content.request.exception.InvalidRequestBodyFormatException;
+import today_store.content.request.repository.GenerationRequestRepository;
+import today_store.content.request.repository.InputImageRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("생성 요청 서비스 테스트")
+class GenerationRequestServiceTest {
+
+    @Mock
+    private GenerationRequestRepository requestRepository;
+
+    @Mock
+    private InputImageRepository imageRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GcsService gcsService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private GenerationRequestService generationRequestService;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        generationRequestService = new GenerationRequestService(
+                requestRepository,
+                imageRepository,
+                userRepository,
+                gcsService,
+                objectMapper
+        );
+    }
+
+    @Test
+    @DisplayName("생성 요청 생성 성공")
+    void shouldCreateGenerationRequest() {
+        // 이미지와 설명 수가 일치하면 요청과 입력 이미지를 저장하고 생성 응답을 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 30, 16, 0);
+        MockMultipartFile firstImage = createMultipartFile("images", "first.png", "first-image");
+        MockMultipartFile secondImage = createMultipartFile("images", "second.png", "second-image");
+        CreateGenerationRequest request = CreateGenerationRequest.builder()
+                .concept("봄 프로모션")
+                .additionalNote("따뜻한 분위기")
+                .targetAge("20대")
+                .targetGender("여성")
+                .imageDescriptions(List.of("정면 이미지", "측면 이미지"))
+                .images(List.of(firstImage, secondImage))
+                .build();
+        given(requestRepository.save(any(GenerationRequest.class))).willAnswer(invocation -> {
+            GenerationRequest saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", requestId);
+            ReflectionTestUtils.setField(saved, "createdAt", createdAt);
+            return saved;
+        });
+        given(gcsService.uploadFile(firstImage, "requests")).willReturn("2026/03/30/requests/uuid_first.png");
+        given(gcsService.uploadFile(secondImage, "requests")).willReturn("2026/03/30/requests/uuid_second.png");
+
+        // when
+        CreateGenerationResponse response = generationRequestService.createRequest(user, request);
+
+        // then
+        assertThat(response.getRequestId()).isEqualTo(requestId);
+        assertThat(response.getCreatedAt()).isEqualTo(createdAt);
+        then(requestRepository).should().save(argThat(saved ->
+                saved.getUser() == user
+                        && saved.getConcept().equals("봄 프로모션")
+                        && saved.getAdditionalNote().equals("따뜻한 분위기")
+                        && saved.getTargetAge().equals("20대")
+                        && saved.getTargetGender().equals("여성")
+        ));
+        then(gcsService).should().uploadFile(firstImage, "requests");
+        then(gcsService).should().uploadFile(secondImage, "requests");
+
+        ArgumentCaptor<InputImage> imageCaptor = ArgumentCaptor.forClass(InputImage.class);
+        then(imageRepository).should(times(2)).save(imageCaptor.capture());
+        assertThat(imageCaptor.getAllValues()).hasSize(2);
+        assertThat(imageCaptor.getAllValues().get(0).getDescription()).isEqualTo("정면 이미지");
+        assertThat(imageCaptor.getAllValues().get(0).getDisplayOrder()).isEqualTo(1);
+        assertThat(imageCaptor.getAllValues().get(1).getDescription()).isEqualTo("측면 이미지");
+        assertThat(imageCaptor.getAllValues().get(1).getDisplayOrder()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("생성 요청 생성 필수값 불일치")
+    void shouldThrowWhenImageCountAndDescriptionCountDoNotMatch() {
+        // 이미지 수와 설명 수가 다르면 C001 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        CreateGenerationRequest request = CreateGenerationRequest.builder()
+                .concept("봄 프로모션")
+                .imageDescriptions(List.of("정면 이미지"))
+                .images(List.of(
+                        createMultipartFile("images", "first.png", "first-image"),
+                        createMultipartFile("images", "second.png", "second-image")
+                ))
+                .build();
+
+        // when
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> generationRequestService.createRequest(user, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING.getMessage());
+        then(requestRepository).should(never()).save(any(GenerationRequest.class));
+    }
+
+    @Test
+    @DisplayName("생성 요청 목록 조회 성공")
+    void shouldReturnGenerationRequestList() {
+        // 삭제되지 않은 요청 목록을 썸네일과 페이징 정보로 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(0, 10);
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                UUID.randomUUID(),
+                "봄 프로모션",
+                "추가 메모",
+                "20대",
+                "여성",
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        Page<GenerationRequest> page = new PageImpl<>(List.of(generationRequest), pageable, 1);
+        InputImage thumbnail = createInputImage(
+                generationRequest,
+                UUID.randomUUID(),
+                "stored-thumbnail",
+                "대표 이미지",
+                1,
+                LocalDateTime.of(2026, 3, 30, 12, 5)
+        );
+        given(requestRepository.findByUserAndIsDeletedFalseOrderByCreatedAtDesc(user, pageable)).willReturn(page);
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest)).willReturn(List.of(thumbnail));
+        given(gcsService.generateSignedUrl("stored-thumbnail")).willReturn("https://signed.example.com/thumbnail");
+
+        // when
+        GenerationRequestListResponse response = generationRequestService.getRequests(user, pageable);
+
+        // then
+        assertThat(response.getData()).hasSize(1);
+        assertThat(response.getData().get(0).getRequestId()).isEqualTo(generationRequest.getId());
+        assertThat(response.getData().get(0).getConcept()).isEqualTo("봄 프로모션");
+        assertThat(response.getData().get(0).getThumbnailUrl()).isEqualTo("https://signed.example.com/thumbnail");
+        assertThat(response.getData().get(0).getImageCount()).isEqualTo(1);
+        assertThat(response.getPagination().getCurrentPage()).isEqualTo(1);
+        assertThat(response.getPagination().getPageSize()).isEqualTo(10);
+        assertThat(response.getPagination().getTotalCount()).isEqualTo(1);
+        assertThat(response.getPagination().getTotalPages()).isEqualTo(1);
+        assertThat(response.getPagination().getHasNext()).isFalse();
+        assertThat(response.getPagination().getHasPrevious()).isFalse();
+    }
+
+    @Test
+    @DisplayName("생성 요청 상세 조회 성공")
+    void shouldReturnGenerationRequestDetail() {
+        // 본인 소유 요청의 상세 정보와 signed URL 이미지를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "봄 프로모션",
+                "추가 메모",
+                "20대",
+                "여성",
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        InputImage firstImage = createInputImage(
+                generationRequest,
+                UUID.randomUUID(),
+                "stored-first",
+                "정면 이미지",
+                1,
+                LocalDateTime.of(2026, 3, 30, 12, 5)
+        );
+        InputImage secondImage = createInputImage(
+                generationRequest,
+                UUID.randomUUID(),
+                "stored-second",
+                "측면 이미지",
+                2,
+                LocalDateTime.of(2026, 3, 30, 12, 6)
+        );
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest)).willReturn(List.of(firstImage, secondImage));
+        given(gcsService.generateSignedUrl("stored-first")).willReturn("https://signed.example.com/first");
+        given(gcsService.generateSignedUrl("stored-second")).willReturn("https://signed.example.com/second");
+
+        // when
+        GenerationRequestDetailResponse response = generationRequestService.getRequestDetail(user, requestId);
+
+        // then
+        assertThat(response.getId()).isEqualTo(requestId);
+        assertThat(response.getUserId()).isEqualTo(user.getId());
+        assertThat(response.getConcept()).isEqualTo("봄 프로모션");
+        assertThat(response.getAdditionalNote()).isEqualTo("추가 메모");
+        assertThat(response.getImages()).hasSize(2);
+        assertThat(response.getImages().get(0).getDisplayOrder()).isEqualTo(1);
+        assertThat(response.getImages().get(0).getUrl()).isEqualTo("https://signed.example.com/first");
+        assertThat(response.getImages().get(1).getDisplayOrder()).isEqualTo(2);
+        assertThat(response.getImages().get(1).getUrl()).isEqualTo("https://signed.example.com/second");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 생성 요청 상세 조회 실패")
+    void shouldThrowWhenRequestDetailDoesNotExist() {
+        // 존재하지 않는 요청 상세를 조회하면 C005 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> generationRequestService.getRequestDetail(user, requestId)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("타 사용자 생성 요청 상세 조회 거부")
+    void shouldThrowWhenAccessingAnotherUsersRequestDetail() {
+        // 다른 사용자의 요청을 조회하면 A008 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        User anotherUser = createUser("other@example.com");
+        UUID requestId = UUID.randomUUID();
+        GenerationRequest generationRequest = createGenerationRequest(
+                anotherUser,
+                requestId,
+                "봄 프로모션",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> generationRequestService.getRequestDetail(user, requestId)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성 요청 삭제 성공")
+    void shouldSoftDeleteGenerationRequest() {
+        // 본인 소유 요청을 삭제하면 soft delete 처리가 되어야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "봄 프로모션",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+
+        // when
+        generationRequestService.deleteRequest(user, requestId);
+
+        // then
+        assertThat(ReflectionTestUtils.getField(generationRequest, "isDeleted")).isEqualTo(true);
+        assertThat(ReflectionTestUtils.getField(generationRequest, "deletedAt")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 생성 요청 삭제 실패")
+    void shouldThrowWhenDeletingMissingRequest() {
+        // 존재하지 않는 요청을 삭제하면 C005 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> generationRequestService.deleteRequest(user, requestId)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("타 사용자 생성 요청 삭제 거부")
+    void shouldThrowWhenDeletingAnotherUsersRequest() {
+        // 다른 사용자의 요청을 삭제하면 A008 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        User anotherUser = createUser("other@example.com");
+        UUID requestId = UUID.randomUUID();
+        GenerationRequest generationRequest = createGenerationRequest(
+                anotherUser,
+                requestId,
+                "봄 프로모션",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> generationRequestService.deleteRequest(user, requestId)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 성공")
+    void shouldUpdateGenerationRequest() throws Exception {
+        // imageConfigs 기반 상태 동기화로 이미지 수정, 추가, 삭제와 응답 요약을 처리해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID keepImageId = UUID.randomUUID();
+        UUID deletedImageId = UUID.randomUUID();
+        UUID addedImageId = UUID.randomUUID();
+        LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 17, 0);
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "기존 컨셉",
+                "기존 메모",
+                "10대",
+                "남성",
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        InputImage keepImage = createInputImage(
+                generationRequest,
+                keepImageId,
+                "stored-keep",
+                "기존 설명",
+                1,
+                LocalDateTime.of(2026, 3, 30, 12, 5)
+        );
+        InputImage deletedImage = createInputImage(
+                generationRequest,
+                deletedImageId,
+                "stored-delete",
+                "삭제될 이미지",
+                2,
+                LocalDateTime.of(2026, 3, 30, 12, 6)
+        );
+        InputImage addedImage = createInputImage(
+                generationRequest,
+                addedImageId,
+                "stored-added",
+                "신규 이미지",
+                3,
+                LocalDateTime.of(2026, 3, 30, 17, 1)
+        );
+        String imageConfigs = """
+                [
+                  {"id":"%s","description":"수정된 설명","displayOrder":2},
+                  {"fileName":"new-image.png","description":"신규 이미지","displayOrder":3}
+                ]
+                """.formatted(keepImageId);
+        MockMultipartFile newImageFile = createMultipartFile("newImages", "new-image.png", "new-image");
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .concept("수정된 컨셉")
+                .additionalNote("수정된 메모")
+                .targetAge("20대")
+                .targetGender("여성")
+                .imageConfigs(imageConfigs)
+                .newImages(List.of(newImageFile))
+                .build();
+        List<ImageConfig> configs = List.of(
+                ImageConfig.builder()
+                        .id(keepImageId)
+                        .description("수정된 설명")
+                        .displayOrder(2)
+                        .build(),
+                ImageConfig.builder()
+                        .fileName("new-image.png")
+                        .description("신규 이미지")
+                        .displayOrder(3)
+                        .build()
+        );
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq(imageConfigs), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(configs);
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest))
+                .willReturn(List.of(keepImage, deletedImage), List.of(keepImage, addedImage));
+        given(imageRepository.findById(keepImageId)).willReturn(Optional.of(keepImage));
+        given(gcsService.uploadFile(newImageFile, "requests")).willReturn("stored-added");
+        given(imageRepository.save(any(InputImage.class))).willReturn(addedImage);
+        given(requestRepository.saveAndFlush(generationRequest)).willAnswer(invocation -> {
+            ReflectionTestUtils.setField(generationRequest, "updatedAt", updatedAt);
+            return generationRequest;
+        });
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            // when
+            UpdateGenerationResponse response = generationRequestService.updateRequest("user@example.com", requestId, request);
+            List<TransactionSynchronization> synchronizations = TransactionSynchronizationManager.getSynchronizations();
+
+            // then
+            assertThat(response.getRequestId()).isEqualTo(requestId);
+            assertThat(response.getConcept()).isEqualTo("수정된 컨셉");
+            assertThat(response.getAdditionalNote()).isEqualTo("수정된 메모");
+            assertThat(response.getTargetAge()).isEqualTo("20대");
+            assertThat(response.getTargetGender()).isEqualTo("여성");
+            assertThat(response.getUpdatedAt()).isEqualTo(updatedAt);
+            assertThat(response.getImageSummary().getTotalCount()).isEqualTo(2);
+            assertThat(response.getImageSummary().getAddedCount()).isEqualTo(1);
+            assertThat(response.getImageSummary().getDeletedCount()).isEqualTo(1);
+            assertThat(generationRequest.getConcept()).isEqualTo("수정된 컨셉");
+            assertThat(keepImage.getDescription()).isEqualTo("수정된 설명");
+            assertThat(keepImage.getDisplayOrder()).isEqualTo(2);
+            then(imageRepository).should().delete(deletedImage);
+            then(requestRepository).should().saveAndFlush(generationRequest);
+            then(gcsService).should(never()).deleteFile("stored-delete");
+            assertThat(synchronizations).hasSize(1);
+
+            synchronizations.forEach(TransactionSynchronization::afterCommit);
+
+            then(gcsService).should().deleteFile("stored-delete");
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 생성 요청 수정 실패")
+    void shouldThrowWhenUpdatingRequestForMissingUser() {
+        // 수정 요청 이메일에 해당하는 사용자가 없으면 A007 예외를 반환해야 한다.
+
+        // given
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("[]")
+                .build();
+        given(userRepository.findByEmail("missing@example.com")).willReturn(Optional.empty());
+
+        // when
+        UserNotFoundException exception = assertThrows(
+                UserNotFoundException.class,
+                () -> generationRequestService.updateRequest("missing@example.com", UUID.randomUUID(), request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("생성 요청 수정 JSON 형식 오류")
+    void shouldThrowWhenImageConfigsJsonIsInvalid() throws Exception {
+        // imageConfigs JSON 파싱에 실패하면 C003 예외를 반환해야 한다.
+
+        // given
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("invalid-json")
+                .build();
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(createUser("user@example.com")));
+        given(objectMapper.readValue(eq("invalid-json"), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willThrow(new JsonProcessingException("invalid") {
+                });
+
+        // when
+        InvalidRequestBodyFormatException exception = assertThrows(
+                InvalidRequestBodyFormatException.class,
+                () -> generationRequestService.updateRequest("user@example.com", UUID.randomUUID(), request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST_BODY_FORMAT);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.INVALID_REQUEST_BODY_FORMAT.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 생성 요청 수정 실패")
+    void shouldThrowWhenUpdatingMissingRequest() throws Exception {
+        // 수정 대상 요청이 없으면 C005 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("[]")
+                .build();
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq("[]"), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(List.of());
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> generationRequestService.updateRequest("user@example.com", requestId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("타 사용자 생성 요청 수정 거부")
+    void shouldThrowWhenUpdatingAnotherUsersRequest() throws Exception {
+        // 다른 사용자의 요청을 수정하면 A008 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        User anotherUser = createUser("other@example.com");
+        UUID requestId = UUID.randomUUID();
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("[]")
+                .build();
+        GenerationRequest generationRequest = createGenerationRequest(
+                anotherUser,
+                requestId,
+                "기존 컨셉",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq("[]"), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(List.of());
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> generationRequestService.updateRequest("user@example.com", requestId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE.getMessage());
+    }
+
+    @Test
+    @DisplayName("다른 요청 소속 이미지 수정 거부")
+    void shouldThrowWhenUpdatingImageBelongingToAnotherRequest() throws Exception {
+        // 다른 요청에 속한 이미지 ID를 수정하려 하면 A008 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID imageId = UUID.randomUUID();
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("""
+                        [{"id":"%s","description":"수정된 설명","displayOrder":1}]
+                        """.formatted(imageId))
+                .build();
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "기존 컨셉",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        GenerationRequest anotherRequest = createGenerationRequest(
+                user,
+                UUID.randomUUID(),
+                "다른 요청",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 11, 0),
+                LocalDateTime.of(2026, 3, 30, 11, 30)
+        );
+        InputImage foreignImage = createInputImage(
+                anotherRequest,
+                imageId,
+                "stored-foreign",
+                "다른 요청 이미지",
+                1,
+                LocalDateTime.of(2026, 3, 30, 11, 5)
+        );
+        List<ImageConfig> configs = List.of(
+                ImageConfig.builder()
+                        .id(imageId)
+                        .description("수정된 설명")
+                        .displayOrder(1)
+                        .build()
+        );
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq(request.getImageConfigs()), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(configs);
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest)).willReturn(List.of());
+        given(imageRepository.findById(imageId)).willReturn(Optional.of(foreignImage));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> generationRequestService.updateRequest("user@example.com", requestId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE.getMessage());
+    }
+
+    @Test
+    @DisplayName("신규 이미지 파일명 불일치")
+    void shouldThrowWhenNewImageFileNameDoesNotMatchConfig() throws Exception {
+        // 신규 이미지 파일명이 imageConfigs와 맞지 않으면 C002 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("""
+                        [{"fileName":"expected.png","description":"신규 이미지","displayOrder":1}]
+                        """)
+                .newImages(List.of(createMultipartFile("newImages", "actual.png", "actual-image")))
+                .build();
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "기존 컨셉",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        List<ImageConfig> configs = List.of(
+                ImageConfig.builder()
+                        .fileName("expected.png")
+                        .description("신규 이미지")
+                        .displayOrder(1)
+                        .build()
+        );
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq(request.getImageConfigs()), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(configs);
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest)).willReturn(List.of());
+
+        // when
+        FileNameMismatchException exception = assertThrows(
+                FileNameMismatchException.class,
+                () -> generationRequestService.updateRequest("user@example.com", requestId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FILE_NAME_MISMATCH);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.FILE_NAME_MISMATCH.getMessage());
+        then(gcsService).should(never()).uploadFile(any(), eq("requests"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기존 이미지 수정 실패")
+    void shouldThrowWhenUpdatingMissingExistingImage() throws Exception {
+        // imageConfigs에 지정한 기존 이미지 ID가 없으면 C005 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID imageId = UUID.randomUUID();
+        UpdateGenerationRequest request = UpdateGenerationRequest.builder()
+                .imageConfigs("""
+                        [{"id":"%s","description":"수정된 설명","displayOrder":1}]
+                        """.formatted(imageId))
+                .build();
+        GenerationRequest generationRequest = createGenerationRequest(
+                user,
+                requestId,
+                "기존 컨셉",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 3, 30, 12, 0),
+                LocalDateTime.of(2026, 3, 30, 12, 30)
+        );
+        List<ImageConfig> configs = List.of(
+                ImageConfig.builder()
+                        .id(imageId)
+                        .description("수정된 설명")
+                        .displayOrder(1)
+                        .build()
+        );
+        given(userRepository.findByEmail("user@example.com")).willReturn(Optional.of(user));
+        given(objectMapper.readValue(eq(request.getImageConfigs()), org.mockito.ArgumentMatchers.<TypeReference<List<ImageConfig>>>any()))
+                .willReturn(configs);
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(generationRequest));
+        given(imageRepository.findByGenerationRequestOrderByDisplayOrderAsc(generationRequest)).willReturn(List.of());
+        given(imageRepository.findById(imageId)).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> generationRequestService.updateRequest("user@example.com", requestId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND.getMessage());
+    }
+
+    private User createUser(String email) {
+        User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        return user;
+    }
+
+    private GenerationRequest createGenerationRequest(
+            User user,
+            UUID requestId,
+            String concept,
+            String additionalNote,
+            String targetAge,
+            String targetGender,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept(concept)
+                .additionalNote(additionalNote)
+                .targetAge(targetAge)
+                .targetGender(targetGender)
+                .build();
+        ReflectionTestUtils.setField(request, "id", requestId);
+        ReflectionTestUtils.setField(request, "createdAt", createdAt);
+        ReflectionTestUtils.setField(request, "updatedAt", updatedAt);
+        return request;
+    }
+
+    private InputImage createInputImage(
+            GenerationRequest generationRequest,
+            UUID imageId,
+            String url,
+            String description,
+            int displayOrder,
+            LocalDateTime createdAt
+    ) {
+        InputImage image = InputImage.builder()
+                .generationRequest(generationRequest)
+                .url(url)
+                .description(description)
+                .displayOrder(displayOrder)
+                .build();
+        ReflectionTestUtils.setField(image, "id", imageId);
+        ReflectionTestUtils.setField(image, "createdAt", createdAt);
+        return image;
+    }
+
+    private MockMultipartFile createMultipartFile(String parameterName, String originalFilename, String content) {
+        return new MockMultipartFile(parameterName, originalFilename, "image/png", content.getBytes());
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #39 

## As-Is
- 생성 요청 관리 API와 관련 서비스 로직은 구현되어 있었지만, 주요 흐름을 검증하는 테스트 코드가 부족
- 생성 요청 CRUD, 페이지네이션 검증, 예외 응답, 이미지 처리 흐름을 자동으로 검증 필요

## To-Be
- 생성 요청 생성/조회/수정/삭제 API에 대한 테스트 코드를 추가
- 생성 요청 서비스 로직에 대한 테스트 코드를 추가
- 페이지네이션 및 요청값 검증, 예외 응답에 대한 테스트를 추가
- GCS 이미지 처리 로직 테스트 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- Spring Boot 3.5.13으로 업그레이드하여 Boot가 관리하는 Spring Security, Netty, Tomcat 의존성 버전을 함께 상향해 Trivy 취약점 4건에 대응했습니다.