### PR TITLE
[Feat] Gemini API 연동 및 컨텐츠 관리 API 구현

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/common/config/AsyncConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package today_store.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/config/GeminiConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/GeminiConfig.java
@@ -1,0 +1,52 @@
+package today_store.common.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Configuration
+@Getter
+public class GeminiConfig {
+
+    @Value("${app.gemini.api-key}")
+    private String apiKey;
+
+    @Getter
+    @Value("${app.gemini.model}")
+    private String model;
+
+    @Value("${app.gemini.endpoint}")
+    private String endpoint;
+
+    @Bean(name = "geminiWebClient")
+    public WebClient geminiWebClient(WebClient.Builder builder) {
+        // Gemini 전용 타임아웃 설정 (60초)
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000) // 연결 타임아웃 10초
+                .responseTimeout(Duration.ofSeconds(60))            // 응답 대기 60초
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(60, TimeUnit.SECONDS))
+                                .addHandlerLast(new WriteTimeoutHandler(60, TimeUnit.SECONDS)));
+
+        return builder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    public String getGenerateUrl() {
+        return String.format("%s/%s:generateContent?key=%s", endpoint, model, apiKey);
+    }
+
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -32,12 +32,22 @@ public enum ErrorCode {
     INVALID_REQUEST_BODY_FORMAT(HttpStatus.BAD_REQUEST, "C003", "Invalid request body format"),
     FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "C004", "File size limit exceeded"),
     GENERATION_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "Request not found or already deleted"),
+    INVALID_REGENERATION_REQUEST(HttpStatus.BAD_REQUEST, "C006", "Empty feedback or Invalid target platform"),
+    CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "C007", "Content not found or already deleted"),
+
+    // Generation Task
+    GENERATION_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "G001", "Generation task is already in progress or completed"),
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "G002", "Task ID not found"),
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Rate limit exceeded. Please try again later."),
 
     // Page
-    INVALID_PAGE_PARAM(HttpStatus.BAD_REQUEST, "P001", "invalid (page, size) parameter");
+    INVALID_PAGE_PARAM(HttpStatus.BAD_REQUEST, "P001", "invalid (page, size) parameter"),
+
+    // AI / Gemini
+    AI_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "AI001", "Gemini returned empty response"),
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI002", "Failed to parse AI response");
 
     private final HttpStatus status;
     private final String code;

--- a/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gcs/GcsService.java
@@ -70,6 +70,31 @@ public class GcsService {
         }
     }
 
+    public String copyFile(String sourceObjectName, String targetFolder) {
+        if (sourceObjectName == null || sourceObjectName.isEmpty()) {
+            return null;
+        }
+
+        String fileName = sourceObjectName.substring(sourceObjectName.lastIndexOf("/") + 1);
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        String uuid = UUID.randomUUID().toString();
+        String targetObjectName = String.format("%s/%s/%s_%s",
+                datePath, targetFolder, uuid, fileName);
+
+        try {
+            Storage.CopyRequest request = Storage.CopyRequest.newBuilder()
+                    .setSource(BlobId.of(bucketName, sourceObjectName))
+                    .setTarget(BlobId.of(bucketName, targetObjectName))
+                    .build();
+            storage.copy(request);
+            log.info("Successfully copied file from {} to {}", sourceObjectName, targetObjectName);
+            return targetObjectName;
+        } catch (Exception e) {
+            log.error("Failed to copy file in GCS: {}", e.getMessage());
+            throw new RuntimeException("GCS copy failed", e);
+        }
+    }
+
     private String sanitize(String input) {
         return (input == null) ? "" : input.replaceAll("[\r\n]", " ");
     }

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiGenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiGenerationRequest.java
@@ -1,0 +1,46 @@
+package today_store.common.gemini.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiGenerationRequest {
+    private List<Content> contents;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Content {
+        private List<Part> parts;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Part {
+        private String text;
+        @JsonProperty("file_data")
+        private FileData fileData;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FileData {
+        @JsonProperty("mime_type")
+        private String mimeType;
+        @JsonProperty("file_uri")
+        private String fileUri;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiParsedResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiParsedResponse.java
@@ -1,0 +1,25 @@
+package today_store.common.gemini.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiParsedResponse {
+    @JsonProperty("photo_info")
+    private String photoInfo;
+    private String text;
+    private List<String> hashtags;
+
+    // Metadata
+    private Integer inputTokens;
+    private Integer outputTokens;
+    private Long responseTimeMs;
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiPromptRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiPromptRequest.java
@@ -1,0 +1,26 @@
+package today_store.common.gemini.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiPromptRequest {
+    private String storeName;
+    private String businessType;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private String targetAge;
+    private String targetGender;
+    private String concept;
+    private String additionalNote;
+    private List<String> imageDescriptions;
+    private List<String> signedUrls;
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiRegenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiRegenerationRequest.java
@@ -12,9 +12,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GeminiRegenerationRequest {
-    private String originalInstagramText;
-    private String originalKarrotText;
-    private String originalNaverText;
+    private String originalText;
+    private List<String> originalHashtags;
     private String feedback;
-    private List<String> targets;
+    private String target;
 }

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiRegenerationRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiRegenerationRequest.java
@@ -1,0 +1,20 @@
+package today_store.common.gemini.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiRegenerationRequest {
+    private String originalInstagramText;
+    private String originalKarrotText;
+    private String originalNaverText;
+    private String feedback;
+    private List<String> targets;
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/dto/GeminiResponse.java
@@ -1,0 +1,67 @@
+package today_store.common.gemini.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeminiResponse {
+    private List<Candidate> candidates;
+    @JsonProperty("usageMetadata")
+    private UsageMetadata usageMetadata;
+
+    private Long responseTimeMs;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Candidate {
+        private Content content;
+        private String finishReason;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Content {
+        private List<Part> parts;
+        private String role;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Part {
+        private String text;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UsageMetadata {
+        @JsonProperty("promptTokenCount")
+        private Integer promptTokenCount;
+        @JsonProperty("candidatesTokenCount")
+        private Integer candidatesTokenCount;
+        @JsonProperty("totalTokenCount")
+        private Integer totalTokenCount;
+    }
+
+    public String getText() {
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+        Candidate firstCandidate = candidates.get(0);
+        if (firstCandidate.getContent() == null || firstCandidate.getContent().getParts() == null || firstCandidate.getContent().getParts().isEmpty()) {
+            return null;
+        }
+        return firstCandidate.getContent().getParts().get(0).getText();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
@@ -193,21 +193,23 @@ public class GeminiService {
                 .map(this::processResponse);
     }
 
-    // 임시로 적용한 재생성 프롬프트(수정 예정)
     public Mono<GeminiParsedResponse> generateProcessedRegenerationContent(GeminiRegenerationRequest request) {
         StringBuilder promptBuilder = new StringBuilder();
         promptBuilder.append("당신은 전문 마케팅 AI 에이전트입니다. 다음 정보를 바탕으로 홍보 문구와 태그를 재작성해주세요.\n\n");
-        promptBuilder.append("### 기존 문구:\n");
-        promptBuilder.append("- 인스타그램: ").append(request.getOriginalInstagramText()).append("\n");
-        promptBuilder.append("- 당근마켓: ").append(request.getOriginalKarrotText()).append("\n");
-        promptBuilder.append("- 네이버: ").append(request.getOriginalNaverText()).append("\n\n");
+        promptBuilder.append("### 대상 플랫폼: ").append(request.getTarget()).append("\n");
+        promptBuilder.append("### 기존 문구 (").append(request.getTarget()).append("):\n");
+        promptBuilder.append(request.getOriginalText()).append("\n\n");
+
+        if (request.getOriginalHashtags() != null && !request.getOriginalHashtags().isEmpty()) {
+            promptBuilder.append("### 기존 해시태그:\n");
+            promptBuilder.append(String.join(", ", request.getOriginalHashtags())).append("\n\n");
+        }
 
         promptBuilder.append("### 사용자 피드백: ").append(request.getFeedback()).append("\n");
 
         promptBuilder.append("응답은 반드시 아래 JSON 형식을 지켜주세요:\n");
         promptBuilder.append("""
                             {
-                                "photo_info": "AI의 시각적 분석 결과",
                                 "text": "생성된 마케팅 문구",
                                 "hashtags": ["#태그1", "#태그2", "#태그3"]
                             }
@@ -216,7 +218,6 @@ public class GeminiService {
         return generateContent(promptBuilder.toString(), null)
                 .map(this::processResponse);
     }
-
 
     public GeminiParsedResponse processResponse(GeminiResponse response) {
         String text = response.getText();

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
@@ -1,0 +1,321 @@
+package today_store.common.gemini.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+import today_store.common.config.GeminiConfig;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gemini.dto.*;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class GeminiService {
+
+    private final GeminiConfig geminiConfig;
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    public GeminiService(GeminiConfig geminiConfig,
+                         @Qualifier("geminiWebClient") WebClient webClient,
+                         ObjectMapper objectMapper) {
+        this.geminiConfig = geminiConfig;
+        this.webClient = webClient;
+        this.objectMapper = objectMapper;
+    }
+
+    public Mono<GeminiResponse> generateContent(String prompt, List<String> signedUrls) {
+        String url = geminiConfig.getGenerateUrl();
+
+        List<GeminiGenerationRequest.Part> parts = new ArrayList<>();
+        parts.add(GeminiGenerationRequest.Part.builder().text(prompt).build());
+
+        if (signedUrls != null) {
+            for (String signedUrl : signedUrls) {
+                parts.add(GeminiGenerationRequest.Part.builder()
+                        .fileData(GeminiGenerationRequest.FileData.builder()
+                                .mimeType("image/jpeg")
+                                .fileUri(signedUrl)
+                                .build())
+                        .build());
+            }
+        }
+
+        GeminiGenerationRequest request = GeminiGenerationRequest.builder()
+                .contents(List.of(GeminiGenerationRequest.Content.builder().parts(parts).build()))
+                .build();
+
+        log.info("Calling Gemini API with Dedicated WebClient: {}", geminiConfig.getModel());
+
+        long startTime = System.currentTimeMillis();
+        return webClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(GeminiResponse.class)
+                .map(response -> {
+                    // response time 직접 계산
+                    response.setResponseTimeMs(System.currentTimeMillis() - startTime);
+                    return response;
+                });
+    }
+
+    // 프롬프트 적용
+    public Mono<GeminiResponse> generateContent(GeminiPromptRequest request) {
+
+        String basePrompt = """
+                        ## ROLE
+                        당신은 소상공인을 위한 전문 SNS 마케팅 카피라이터 '오늘의 가게(Today's Store)' AI 엔진입니다.
+                        사용자가 업로드한 사진을 분석하고, 매장의 특성을 살린 매력적인 홍보 문구를 생성하는 역할을 수행합니다.
+                                        
+                        ## DATA DEFINITION: photo_info
+                        - 정의: AI가 업로드된 이미지를 보고 직접 분석한 시각적 정보의 요약입니다.
+                        - 역할: 생성된 문구의 직접적인 근거가 되며, 응답 품질 점검 시 디버깅 데이터로 활용됩니다.
+                                        
+                        ## STYLE GUIDELINES
+                        1. 감성적: 따뜻하고 스토리텔링 중심의 톤, 감성적 형용사와 이모지 활용.
+                        2. 정보제공: 객관적이고 상세한 정보 전달, 가격/스펙/구성 위주.
+                        3. 전문성: 신뢰감 있는 전문적 톤, 브랜드 가치 강조, 전문 용어 활용.
+                        4. 친근: 이웃 같은 편안한 대화 톤, 구어체 및 공감 유도.
+                                        
+                        ## SUCCESS CRITERIA
+                        1. 이미지를 분석해 photo_info를 작성합니다.
+                        2. 입력된 조건을 반영해 마케팅 문구를 작성합니다.
+                        3. 반드시 JSON 객체만 출력합니다.
+                                        
+                        ## OUTPUT GUARDRAIL
+                        - "본문"에는 해시태그(#...)를 절대 포함하지 마세요.
+                        - 해시태그는 반드시 "해시태그" 배열에만 넣으세요.
+                        - 본문 마지막 줄에 해시태그를 반복 출력하지 마세요.
+                """;
+
+        StringBuilder promptBuilder = new StringBuilder();
+
+        List<String> descriptions = request.getImageDescriptions();
+        String imageDescriptionsStr;
+        if (descriptions == null || descriptions.isEmpty()) {
+            imageDescriptionsStr = "제공되지 않음";
+        } else {
+            List<String> indexedList = new ArrayList<>();
+            for (int i = 0; i < descriptions.size(); i++) {
+                String desc = (descriptions.get(i) != null && !descriptions.get(i).isBlank())
+                        ? descriptions.get(i)
+                        : "설명 없음";
+                indexedList.add(String.format("[사진 %d]: %s", i + 1, desc));
+            }
+            imageDescriptionsStr = String.join(", ", indexedList);
+        }
+
+        promptBuilder
+                .append(basePrompt)
+                .append(String.format("""
+                        ## USER INPUT
+                        - store_name: %s
+                        - business_type: %s
+                        - address: %s
+                        - lat: %s
+                        - lng: %s
+                        - target_age : %s
+                        - target_gender : %s
+                        - style: %s
+                        - additional_note: %s
+                        - image_descriptions : %s
+                        - image_count: %d (최대 5)
+                        """,
+                        request.getStoreName(),
+                        request.getBusinessType(),
+                        request.getAddress(),
+                        request.getLatitude(),
+                        request.getLongitude(),
+                        request.getTargetAge(),
+                        request.getTargetGender(),
+                        request.getConcept(),
+                        request.getAdditionalNote(),
+                        imageDescriptionsStr,
+                        request.getSignedUrls() != null ? request.getSignedUrls().size() : 0
+                ))
+                .append(
+                        """
+                        ## IMPORTANT RULES
+                        1. 상호명은 반드시 store_name만 사용하세요. 이미지에서 읽힌 텍스트를 상호명으로 추정하지 마세요.
+                        2. 이미지 텍스트(OCR)는 메뉴/분위기/특징 보조 정보로만 사용하세요.
+                        3. 본문은 가독성 높은 2~4문장으로 작성하고, 한 줄 장문으로 뭉치지 않게 작성하세요.
+                        4. 문장 간 자연스러운 줄바꿈을 1~2회 허용하세요.
+                        5. 반드시 JSON 객체만 출력하세요. 코드펜스/설명문은 금지합니다.
+                        6. JSON 키는 정확히 다음 3개만 사용하세요: photo_info, text, hashtags
+
+                        ## FEW-SHOT (좋은 예)
+                        입력 조건:
+                        - store_name: 홍길동 카페
+                        - style: 친근함
+
+                        출력 예:
+                        {
+                          "photo_info": "우드톤 인테리어, 라떼 아트, 디저트 진열대가 보이는 아늑한 카페 공간",
+                          "text": "오늘은 한 템포 쉬어가고 싶은 날, 홍길동 카페에서 여유를 채워보세요. \n 부드러운 라떼와 달콤한 디저트로 일상에 작은 기분전환을 더해드립니다.",
+                          "hashtags": ["#카페", "#디저트", "#라떼"]
+                        }
+
+                                                
+                        ## FEW-SHOT (나쁜 예: 금지)
+                        - 한 줄에 과도하게 긴 문장만 작성
+                        - 이미지에서 본 텍스트를 store_name으로 바꿔 부르는 행위
+                        - 본문 끝에 해시태그 나열
+                                                
+                        ## OUTPUT JSON STRUCTURE
+                        {
+                          "photo_info": "AI의 시각적 분석 결과",
+                          "text": "생성된 마케팅 문구",
+                          "hashtags": ["#태그1", "#태그2", "#태그3"]
+                        }
+                        """
+                );
+
+
+
+        return generateContent(promptBuilder.toString(), request.getSignedUrls());
+    }
+
+
+    public Mono<GeminiParsedResponse> generateProcessedContent(GeminiPromptRequest request) {
+        return generateContent(request)
+                .map(this::processResponse);
+    }
+
+    // 임시로 적용한 재생성 프롬프트(수정 예정)
+    public Mono<GeminiParsedResponse> generateProcessedRegenerationContent(GeminiRegenerationRequest request) {
+        StringBuilder promptBuilder = new StringBuilder();
+        promptBuilder.append("당신은 전문 마케팅 AI 에이전트입니다. 다음 정보를 바탕으로 홍보 문구와 태그를 재작성해주세요.\n\n");
+        promptBuilder.append("### 기존 문구:\n");
+        promptBuilder.append("- 인스타그램: ").append(request.getOriginalInstagramText()).append("\n");
+        promptBuilder.append("- 당근마켓: ").append(request.getOriginalKarrotText()).append("\n");
+        promptBuilder.append("- 네이버: ").append(request.getOriginalNaverText()).append("\n\n");
+
+        promptBuilder.append("### 사용자 피드백: ").append(request.getFeedback()).append("\n");
+
+        promptBuilder.append("응답은 반드시 아래 JSON 형식을 지켜주세요:\n");
+        promptBuilder.append("""
+                            {
+                                "photo_info": "AI의 시각적 분석 결과",
+                                "text": "생성된 마케팅 문구",
+                                "hashtags": ["#태그1", "#태그2", "#태그3"]
+                            }
+                """);
+
+        return generateContent(promptBuilder.toString(), null)
+                .map(this::processResponse);
+    }
+
+
+    public GeminiParsedResponse processResponse(GeminiResponse response) {
+        String text = response.getText();
+        if (text == null) {
+            throw new CustomException(ErrorCode.AI_RESPONSE_EMPTY);
+        }
+
+        GeminiParsedResponse parsed = parseGeminiResponse(text);
+
+        // 후처리 적용
+        List<String> normalizedHashtags = normalizeHashtags(parsed.getHashtags());
+        String cleanText = removeHashtagTailFromBody(parsed.getText(), normalizedHashtags);
+        cleanText = softWrapLongText(cleanText);
+
+        parsed.setHashtags(normalizedHashtags);
+        parsed.setText(cleanText);
+
+        // 메타데이터 복사
+        if (response.getUsageMetadata() != null) {
+            parsed.setInputTokens(response.getUsageMetadata().getPromptTokenCount());
+            parsed.setOutputTokens(response.getUsageMetadata().getCandidatesTokenCount());
+        }
+        parsed.setResponseTimeMs(response.getResponseTimeMs());
+
+        return parsed;
+    }
+
+    private GeminiParsedResponse parseGeminiResponse(String text) {
+        String cleanJson = text.replaceAll("```json|```", "").trim();
+        try {
+            return objectMapper.readValue(cleanJson, GeminiParsedResponse.class);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Gemini response: {}", text);
+            throw new CustomException(ErrorCode.AI_PARSE_ERROR);
+        }
+    }
+
+    // 가드레일 1
+    private List<String> normalizeHashtags(List<String> hashtags) {
+        if (hashtags == null) return Collections.emptyList();
+
+        return hashtags.stream()
+                .filter(s -> s != null && !s.trim().isEmpty())
+                .map(String::trim)
+                .map(s -> s.startsWith("#") ? s : "#" + s)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        ArrayList::new
+                ));
+    }
+
+
+    // 가드레일 2
+    private String removeHashtagTailFromBody(String body, List<String> hashtags) {
+        if (body == null || body.trim().isEmpty()) return "";
+        if (hashtags == null || hashtags.isEmpty()) return body.trim();
+
+        String[] lines = body.split("\\r?\\n");
+        if (lines.length == 0) return body.trim();
+
+        String lastLine = lines[lines.length - 1].trim();
+        if (lastLine.isEmpty()) return body.trim();
+
+        Pattern hashtagPattern = Pattern.compile("#[^\\s#]+");
+        var matcher = hashtagPattern.matcher(lastLine);
+
+        List<String> lastLineTokens = new ArrayList<>();
+        while (matcher.find()) {
+            lastLineTokens.add(matcher.group());
+        }
+
+        if (!lastLineTokens.isEmpty()) {
+            boolean allAreHashtags = lastLineTokens.stream().allMatch(hashtags::contains);
+            String withoutHashtags = lastLine.replaceAll("#[^\\s#]+", "").trim();
+
+            if (allAreHashtags && withoutHashtags.isEmpty()) {
+                return Arrays.stream(lines, 0, lines.length - 1)
+                        .collect(Collectors.joining("\n")).trim();
+            }
+        }
+
+        return body.trim();
+    }
+
+    // 가드레일 3
+    private String softWrapLongText(String text) {
+        if (text == null || text.trim().isEmpty()) return "";
+
+        String cleaned = text.replaceAll("\\s+", " ").trim();
+        if (text.contains("\n")) return text.trim();
+
+        String[] chunks = cleaned.split("(?<=[.!?])\\s+");
+        if (chunks.length >= 2) {
+            return Arrays.stream(chunks)
+                    .limit(4)
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.joining("\n"));
+        }
+        return cleaned;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/controller/ContentController.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/controller/ContentController.java
@@ -1,0 +1,98 @@
+package today_store.content.content.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import today_store.authentication.entity.User;
+import today_store.common.ratelimit.RateLimit;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.content.content.dto.*;
+import today_store.content.content.service.ContentService;
+import today_store.user.service.UserService;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/contents")
+public class ContentController {
+
+    private final ContentService contentService;
+    private final UserService userService;
+
+    @PostMapping("/{requestId}/generate")
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public GenerateContentResponse generateContent(
+            @PathVariable UUID requestId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return contentService.startGeneration(user, requestId);
+    }
+
+    @GetMapping("/task/{apiLogId}")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public TaskStatusResponse getTaskStatus(
+            @PathVariable UUID apiLogId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return contentService.getTaskStatus(user, apiLogId);
+    }
+
+    @GetMapping("/{requestId}/contents")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public ContentListResponse getContentList(
+            @PathVariable UUID requestId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return contentService.getContentList(user, requestId);
+    }
+
+    @GetMapping("/{contentId}")
+    @RateLimit(tier = RateLimitTier.LOW)
+    public ContentResponse getContent(
+            @PathVariable UUID contentId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return contentService.getContent(user, contentId);
+    }
+
+    @PatchMapping("/{contentId}")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    public ContentResponse updateContent(
+            @PathVariable UUID contentId,
+            @RequestBody UpdateContentRequest request,
+            Authentication authentication) {
+
+        return contentService.updateContent(authentication.getName(), contentId, request);
+    }
+
+    @PostMapping("/{contentId}/regenerate")
+    @RateLimit(tier = RateLimitTier.HIGH)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public GenerateContentResponse regenerateContent(
+            @PathVariable UUID contentId,
+            @Valid @RequestBody RegenerateContentRequest request,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        return contentService.startRegeneration(user, contentId, request);
+    }
+
+    @DeleteMapping("/{contentId}")
+    @RateLimit(tier = RateLimitTier.MIDDLE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteContent(
+            @PathVariable UUID contentId,
+            Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+        contentService.deleteContent(user, contentId);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentListResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentListResponse.java
@@ -1,0 +1,58 @@
+package today_store.content.content.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.content.content.entity.Content;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentListResponse {
+    private UUID requestId;
+    private List<ContentSummary> contents;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentSummary {
+        private UUID contentId;
+        private Boolean isPosted;
+        private String instagramPreview;
+        private String karrotPreview;
+        private String naverPreview;
+        private LocalDateTime createdAt;
+    }
+
+    public static ContentListResponse from(UUID requestId, List<Content> contents, Set<UUID> postedContentIds) {
+        return ContentListResponse.builder()
+                .requestId(requestId)
+                .contents(contents.stream()
+                        .map(c -> ContentSummary.builder()
+                                .contentId(c.getId())
+                                .isPosted(postedContentIds.contains(c.getId()))
+                                .instagramPreview(makePreview(c.getInstagramText()))
+                                .karrotPreview(makePreview(c.getKarrotText()))
+                                .naverPreview(makePreview(c.getNaverText()))
+                                .createdAt(c.getCreatedAt())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private static String makePreview(String text) {
+        if (text == null || text.isEmpty()) return "";
+        String singleLine = text.replace("\n", " ").replace("\r", " ").trim();
+        if (singleLine.length() <= 30) return singleLine;
+        return singleLine.substring(0, 30) + "...";
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentResponse.java
@@ -1,0 +1,91 @@
+package today_store.content.content.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentImage;
+import today_store.content.content.entity.GenerationType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentResponse {
+    private UUID id;
+    private UUID requestId;
+    private GenerationType generationType;
+    private Boolean isPosted;
+    private LocalDateTime createdAt;
+    private ContentData contentData;
+    private List<ContentImageResponse> images;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentData {
+        private PlatformData instagram;
+        private PlatformData karrot;
+        private PlatformData naver;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlatformData {
+        private String text;
+        private List<String> hashtags;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentImageResponse {
+        private UUID id;
+        private UUID inputImageId;
+        private String url;
+        private LocalDateTime createdAt;
+    }
+
+    public static ContentResponse from(Content content, List<ContentImage> images, boolean isPosted, Function<String, String> urlSigner) {
+        return ContentResponse.builder()
+                .id(content.getId())
+                .requestId(content.getGenerationRequest().getId())
+                .generationType(content.getGenerationType())
+                .isPosted(isPosted)
+                .createdAt(content.getCreatedAt())
+                .contentData(ContentData.builder()
+                        .instagram(PlatformData.builder()
+                                .text(content.getInstagramText())
+                                .hashtags(content.getInstagramHashtags())
+                                .build())
+                        .karrot(PlatformData.builder()
+                                .text(content.getKarrotText())
+                                .hashtags(content.getKarrotTags())
+                                .build())
+                        .naver(PlatformData.builder()
+                                .text(content.getNaverText())
+                                .hashtags(content.getNaverKeywords())
+                                .build())
+                        .build())
+                .images(images.stream()
+                        .map(img -> ContentImageResponse.builder()
+                                .id(img.getId())
+                                .inputImageId(img.getInputImage().getId())
+                                .url(urlSigner != null ? urlSigner.apply(img.getUrl()) : img.getUrl())
+                                .createdAt(img.getCreatedAt())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/ContentResponse.java
@@ -81,7 +81,7 @@ public class ContentResponse {
                 .images(images.stream()
                         .map(img -> ContentImageResponse.builder()
                                 .id(img.getId())
-                                .inputImageId(img.getInputImage().getId())
+                                .inputImageId(img.getInputImageId())
                                 .url(urlSigner != null ? urlSigner.apply(img.getUrl()) : img.getUrl())
                                 .createdAt(img.getCreatedAt())
                                 .build())

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/GenerateContentResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/GenerateContentResponse.java
@@ -1,0 +1,19 @@
+package today_store.content.content.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerateContentResponse {
+    private UUID requestId;
+    private UUID taskId;
+    private LocalDateTime startedAt;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
@@ -1,0 +1,25 @@
+package today_store.content.content.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class
+RegenerateContentRequest {
+    @NotBlank(message = "Feedback is required")
+    private String feedback;
+    
+    private boolean regenerateImage;
+    
+    @NotEmpty(message = "Target platforms are required")
+    private List<String> targets;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
@@ -17,9 +17,9 @@ public class
 RegenerateContentRequest {
     @NotBlank(message = "Feedback is required")
     private String feedback;
-    
+
     private boolean regenerateImage;
-    
-    @NotEmpty(message = "Target platforms are required")
-    private List<String> targets;
+
+    @NotBlank(message = "Target platform is required")
+    private String target;
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/TaskStatusResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/TaskStatusResponse.java
@@ -1,0 +1,25 @@
+package today_store.content.content.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskStatusResponse {
+    @JsonProperty("task_id")
+    private UUID taskId;
+    
+    private String status;
+    
+    private String result;
+    
+    @JsonProperty("error_message")
+    private String errorMessage;
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/UpdateContentRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/UpdateContentRequest.java
@@ -1,0 +1,27 @@
+package today_store.content.content.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateContentRequest {
+    private PlatformUpdate instagram;
+    private PlatformUpdate karrot;
+    private PlatformUpdate naver;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PlatformUpdate {
+        private String text;
+        private List<String> hashtags;
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/ApiLog.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/ApiLog.java
@@ -2,11 +2,7 @@ package today_store.content.content.entity;
 
 import jakarta.persistence.*;
 import jakarta.persistence.GenerationType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import today_store.content.request.entity.GenerationRequest;
 
@@ -17,9 +13,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "api_logs")
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ApiLog {
 
@@ -61,4 +56,18 @@ public class ApiLog {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public void completeSuccess(Content content, Integer inputTokens, Integer outputTokens, BigDecimal costUsd, Integer responseTimeMs) {
+        this.status = ApiStatus.SUCCESS;
+        this.content = content;
+        this.inputTokens = inputTokens;
+        this.outputTokens = outputTokens;
+        this.costUsd = costUsd;
+        this.responseTimeMs = responseTimeMs;
+    }
+
+    public void completeError(String errorMessage) {
+        this.status = ApiStatus.ERROR;
+        this.errorMessage = errorMessage;
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/ApiStatus.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/ApiStatus.java
@@ -1,6 +1,7 @@
 package today_store.content.content.entity;
 
 public enum ApiStatus {
+    PROCESSING,
     SUCCESS,
     ERROR,
     TIMEOUT

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/Content.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/Content.java
@@ -1,11 +1,7 @@
 package today_store.content.content.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -20,9 +16,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "contents")
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Content {
 
@@ -40,6 +35,7 @@ public class Content {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "instagram_hashtags", columnDefinition = "JSONB")
+    @Builder.Default
     private List<String> instagramHashtags = new ArrayList<>();
 
     @Column(name = "karrot_text", columnDefinition = "TEXT")
@@ -47,6 +43,7 @@ public class Content {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "karrot_tags", columnDefinition = "JSONB")
+    @Builder.Default
     private List<String> karrotTags = new ArrayList<>();
 
     @Column(name = "naver_text", columnDefinition = "TEXT")
@@ -54,6 +51,7 @@ public class Content {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "naver_keywords", columnDefinition = "JSONB")
+    @Builder.Default
     private List<String> naverKeywords = new ArrayList<>();
 
     @CreationTimestamp
@@ -77,4 +75,24 @@ public class Content {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void updateInstagram(String text, List<String> hashtags) {
+        if (text != null) this.instagramText = text;
+        if (hashtags != null) this.instagramHashtags = hashtags;
+    }
+
+    public void updateKarrot(String text, List<String> tags) {
+        if (text != null) this.karrotText = text;
+        if (tags != null) this.karrotTags = tags;
+    }
+
+    public void updateNaver(String text, List<String> keywords) {
+        if (text != null) this.naverText = text;
+        if (keywords != null) this.naverKeywords = keywords;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentImage.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentImage.java
@@ -2,11 +2,7 @@ package today_store.content.content.entity;
 
 import jakarta.persistence.*;
 import jakarta.persistence.GenerationType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import today_store.content.request.entity.InputImage;
 
@@ -18,7 +14,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ContentImage {
 

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentImage.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentImage.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 @Entity
 @Table(name = "content_images")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -27,9 +26,8 @@ public class ContentImage {
     @JoinColumn(name = "content_id", nullable = false)
     private Content content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "input_image_id", nullable = false)
-    private InputImage inputImage;
+    @Column(name = "input_image_id", nullable = false)
+    private UUID inputImageId;
 
     @Column(nullable = false, length = 500)
     private String url;

--- a/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentPost.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/entity/ContentPost.java
@@ -2,11 +2,7 @@ package today_store.content.content.entity;
 
 import jakarta.persistence.*;
 import jakarta.persistence.GenerationType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -16,7 +12,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ContentPost {
 

--- a/backend-spring/today-store/src/main/java/today_store/content/content/exception/ContentNotFoundException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/exception/ContentNotFoundException.java
@@ -1,0 +1,9 @@
+package today_store.content.content.exception;
+
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class ContentNotFoundException extends CustomException {
+    public ContentNotFoundException(){super(ErrorCode.CONTENT_NOT_FOUND);}
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/exception/GenerationAlreadyInProgressException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/exception/GenerationAlreadyInProgressException.java
@@ -1,0 +1,9 @@
+package today_store.content.content.exception;
+
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class GenerationAlreadyInProgressException extends CustomException {
+    public GenerationAlreadyInProgressException(){super(ErrorCode.GENERATION_ALREADY_IN_PROGRESS);}
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/exception/InvalidRegenerationRequestException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/exception/InvalidRegenerationRequestException.java
@@ -1,0 +1,12 @@
+package today_store.content.content.exception;
+
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class InvalidRegenerationRequestException extends CustomException {
+    public InvalidRegenerationRequestException() {
+        super(ErrorCode.INVALID_REGENERATION_REQUEST);
+    }
+}
+

--- a/backend-spring/today-store/src/main/java/today_store/content/content/exception/TaskNotFoundException.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/exception/TaskNotFoundException.java
@@ -1,0 +1,9 @@
+package today_store.content.content.exception;
+
+
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+
+public class TaskNotFoundException extends CustomException {
+    public TaskNotFoundException(){super(ErrorCode.TASK_NOT_FOUND);}
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/repository/ApiLogRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/repository/ApiLogRepository.java
@@ -1,0 +1,10 @@
+package today_store.content.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import today_store.content.content.entity.ApiLog;
+
+import java.util.UUID;
+
+public interface ApiLogRepository extends JpaRepository<ApiLog, UUID> {
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentImageRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentImageRepository.java
@@ -1,0 +1,12 @@
+package today_store.content.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentImage;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ContentImageRepository extends JpaRepository<ContentImage, UUID> {
+    List<ContentImage> findByContentOrderByCreatedAtAsc(Content content);
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentPostRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentPostRepository.java
@@ -1,0 +1,18 @@
+package today_store.content.content.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentPost;
+import today_store.content.content.entity.PublishStatus;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface ContentPostRepository extends JpaRepository<ContentPost, UUID> {
+    boolean existsByContentAndStatus(Content content, PublishStatus status);
+    
+    @Query("SELECT cp.content.id FROM ContentPost cp WHERE cp.content IN :contents AND cp.status = :status")
+    List<UUID> findContentIdsByContentInAndStatus(Collection<Content> contents, PublishStatus status);
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/repository/ContentRepository.java
@@ -1,0 +1,15 @@
+package today_store.content.content.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import today_store.content.content.entity.Content;
+import today_store.content.request.entity.GenerationRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ContentRepository extends JpaRepository<Content, UUID> {
+    List<Content> findByGenerationRequestAndIsDeletedFalseOrderByCreatedAtDesc(GenerationRequest generationRequest);
+    Optional<Content> findByIdAndIsDeletedFalse(UUID id);
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
@@ -317,12 +317,28 @@ public class ContentService {
                     return transactionTemplate.execute(status -> {
                         Content originalContent = contentRepository.findById(originalContentId).orElseThrow();
 
+                        String originalText;
+                        List<String> originalHashtags;
+                        String target = regenerateRequest.getTarget();
+                        if ("INSTAGRAM".equals(target)) {
+                            originalText = originalContent.getInstagramText();
+                            originalHashtags = originalContent.getInstagramHashtags();
+                        } else if ("KARROT".equals(target)) {
+                            originalText = originalContent.getKarrotText();
+                            originalHashtags = originalContent.getKarrotTags();
+                        } else if ("NAVER".equals(target)) {
+                            originalText = originalContent.getNaverText();
+                            originalHashtags = originalContent.getNaverKeywords();
+                        } else {
+                            originalText = "";
+                            originalHashtags = List.of();
+                        }
+
                         return GeminiRegenerationRequest.builder()
-                                .originalInstagramText(originalContent.getInstagramText())
-                                .originalKarrotText(originalContent.getKarrotText())
-                                .originalNaverText(originalContent.getNaverText())
+                                .originalText(originalText)
+                                .originalHashtags(originalHashtags)
                                 .feedback(regenerateRequest.getFeedback())
-                                .targets(regenerateRequest.getTargets())
+                                .target(target)
                                 .build();
                     });
                 })
@@ -335,16 +351,16 @@ public class ContentService {
                         GenerationRequest request = requestRepository.findById(requestId).orElseThrow();
                         Content originalContent = contentRepository.findById(originalContentId).orElseThrow();
 
-                        // Merge with original content (Only update target platforms)
-                        List<String> targets = regenerateRequest.getTargets();
+                        // Merge with original content (Only update target platform)
+                        String target = regenerateRequest.getTarget();
                         Content newContent = Content.builder()
                                 .generationRequest(request)
-                                .instagramText(targets.contains("INSTAGRAM") && parsed.getText() != null ? parsed.getText() : originalContent.getInstagramText())
-                                .instagramHashtags(targets.contains("INSTAGRAM") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getInstagramHashtags())
-                                .karrotText(targets.contains("KARROT") && parsed.getText() != null ? parsed.getText() : originalContent.getKarrotText())
-                                .karrotTags(targets.contains("KARROT") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getKarrotTags())
-                                .naverText(targets.contains("NAVER") && parsed.getText() != null ? parsed.getText() : originalContent.getNaverText())
-                                .naverKeywords(targets.contains("NAVER") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getNaverKeywords())
+                                .instagramText("INSTAGRAM".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getInstagramText())
+                                .instagramHashtags("INSTAGRAM".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getInstagramHashtags())
+                                .karrotText("KARROT".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getKarrotText())
+                                .karrotTags("KARROT".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getKarrotTags())
+                                .naverText("NAVER".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getNaverText())
+                                .naverKeywords("NAVER".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getNaverKeywords())
                                 .generationType(GenerationType.TEXT_ONLY)
                                 .aiModel(apiLog.getModel())
                                 .createdAt(LocalDateTime.now())

--- a/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
@@ -1,0 +1,401 @@
+package today_store.content.content.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import today_store.authentication.entity.User;
+import today_store.authentication.exception.AccessDeniedToResourceException;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.config.GeminiConfig;
+import today_store.common.gcs.GcsService;
+import today_store.common.gemini.dto.GeminiPromptRequest;
+import today_store.common.gemini.dto.GeminiRegenerationRequest;
+import today_store.common.gemini.service.GeminiService;
+import today_store.content.content.dto.*;
+import today_store.content.content.entity.*;
+import today_store.content.content.repository.ApiLogRepository;
+import today_store.content.content.repository.ContentImageRepository;
+import today_store.content.content.repository.ContentPostRepository;
+import today_store.content.content.repository.ContentRepository;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+import today_store.content.request.repository.GenerationRequestRepository;
+import today_store.content.request.repository.InputImageRepository;
+import today_store.store.entity.Store;
+import today_store.store.repository.StoreRepository;
+import today_store.store.exception.StoreNotFoundException;
+import today_store.content.request.exception.GenerationRequestNotFoundException;
+import today_store.content.content.exception.TaskNotFoundException;
+import today_store.content.content.exception.ContentNotFoundException;
+import today_store.authentication.exception.UserNotFoundException;
+
+
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ContentService {
+
+    private final ContentRepository contentRepository;
+    private final ContentImageRepository contentImageRepository;
+    private final ApiLogRepository apiLogRepository;
+    private final GenerationRequestRepository requestRepository;
+    private final InputImageRepository inputImageRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+    private final ContentPostRepository contentPostRepository;
+    private final GeminiService geminiService;
+    private final GcsService gcsService;
+    private final TransactionTemplate transactionTemplate;
+    private final GeminiConfig geminiConfig;
+
+    @Transactional
+    public GenerateContentResponse startGeneration(User user, UUID requestId) {
+        GenerationRequest request = requestRepository.findByIdAndIsDeletedFalse(requestId)
+                .orElseThrow(GenerationRequestNotFoundException::new);
+
+        if (!request.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        // Create ApiLog for tracking
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model(geminiConfig.getModel())
+                .status(ApiStatus.PROCESSING)
+                .build();
+
+        ApiLog savedLog = apiLogRepository.save(apiLog);
+
+        // Start generation in background
+        generateContentAsync(request.getId(), savedLog.getId());
+
+        return GenerateContentResponse.builder()
+                .requestId(requestId)
+                .taskId(savedLog.getId())
+                .startedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Async
+    public void generateContentAsync(UUID requestId, UUID apiLogId) {
+        log.info("Starting background generation for request: {}, apiLog: {}", requestId, apiLogId);
+
+        Mono.fromCallable(() -> {
+                    return transactionTemplate.execute(status -> {
+                        GenerationRequest request = requestRepository.findById(requestId).orElseThrow();
+
+                        List<InputImage> inputImages = inputImageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request);
+                        List<String> signedUrls = inputImages.stream()
+                                .map(img -> gcsService.generateSignedUrl(img.getUrl()))
+                                .collect(Collectors.toList());
+                        List<String> imageDescriptions = inputImages.stream()
+                                .map(InputImage::getDescription)
+                                .collect(Collectors.toList());
+
+                        Store store = storeRepository.findByUser(request.getUser())
+                                .orElseThrow(StoreNotFoundException::new);
+
+                        return new GeminiPromptRequest(
+                                store.getStoreName(),
+                                store.getBusinessType(),
+                                store.getAddress(),
+                                store.getLatitude() != null ? store.getLatitude().doubleValue() : null,
+                                store.getLongitude() != null ? store.getLongitude().doubleValue() : null,
+                                request.getTargetAge(),
+                                request.getTargetGender(),
+                                request.getConcept(),
+                                request.getAdditionalNote(),
+                                imageDescriptions,
+                                signedUrls
+                        );
+                    });
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(geminiService::generateProcessedContent)
+                .publishOn(Schedulers.boundedElastic())
+                .doOnNext(parsed -> {
+                    transactionTemplate.execute(status -> {
+                        ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
+                        GenerationRequest request = requestRepository.findById(requestId).orElseThrow();
+                        List<InputImage> inputImages = inputImageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request);
+
+                        // Save Content
+                        Content content = Content.builder()
+                                .generationRequest(request)
+                                .instagramText(parsed.getText())
+                                .instagramHashtags(parsed.getHashtags() != null ? parsed.getHashtags() : List.of())
+                                .karrotText(parsed.getText())
+                                .karrotTags(parsed.getHashtags() != null ? parsed.getHashtags() : List.of())
+                                .naverText(parsed.getText())
+                                .naverKeywords(parsed.getHashtags() != null ? parsed.getHashtags() : List.of())
+                                .generationType(GenerationType.ALL)
+                                .aiModel(apiLog.getModel())
+                                .createdAt(LocalDateTime.now())
+                                .updatedAt(LocalDateTime.now())
+                                .build();
+
+                        Content savedContent = contentRepository.save(content);
+
+                        // Save ContentImages (map from input images)
+                        for (InputImage inputImage : inputImages) {
+                            ContentImage contentImage = ContentImage.builder()
+                                    .content(savedContent)
+                                    .inputImage(inputImage)
+                                    .url(inputImage.getUrl())
+                                    .build();
+                            contentImageRepository.save(contentImage);
+                        }
+
+                        // Update ApiLog with Metadata from parsed response
+                        Integer inputTokens = parsed.getInputTokens();
+                        Integer outputTokens = parsed.getOutputTokens();
+                        BigDecimal costUsd = calculateCost(inputTokens, outputTokens);
+                        Integer responseTimeMs = parsed.getResponseTimeMs() != null ? parsed.getResponseTimeMs().intValue() : null;
+
+                        apiLog.completeSuccess(savedContent, inputTokens, outputTokens, costUsd, responseTimeMs);
+                        apiLogRepository.save(apiLog);
+                        return null;
+                    });
+                })
+                .doOnError(e -> {
+                    log.error("Error during background generation for apiLog {}: {}", apiLogId, e.getMessage(), e);
+                    transactionTemplate.execute(status -> {
+                        ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
+                        apiLog.completeError(e.getMessage());
+                        apiLogRepository.save(apiLog);
+                        return null;
+                    });
+                })
+                .subscribe();
+    }
+
+    @Transactional(readOnly = true)
+    public TaskStatusResponse getTaskStatus(User user, UUID apiLogId) {
+        ApiLog apiLog = apiLogRepository.findById(apiLogId)
+                .orElseThrow(TaskNotFoundException::new);
+
+        if (!apiLog.getGenerationRequest().getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        String result = apiLog.getContent() != null ? apiLog.getContent().getId().toString() : null;
+
+        return TaskStatusResponse.builder()
+                .taskId(apiLog.getId())
+                .status(apiLog.getStatus().name().toLowerCase())
+                .result(result)
+                .errorMessage(apiLog.getErrorMessage())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public ContentResponse getContent(User user, UUID contentId) {
+        Content content = contentRepository.findByIdAndIsDeletedFalse(contentId)
+                .orElseThrow(ContentNotFoundException::new);
+
+        if (!content.getGenerationRequest().getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        List<ContentImage> images = contentImageRepository.findByContentOrderByCreatedAtAsc(content);
+
+        boolean isPosted = contentPostRepository.existsByContentAndStatus(content, PublishStatus.COMPLETED);
+
+        return ContentResponse.from(content, images, isPosted, gcsService::generateSignedUrl);
+    }
+
+    @Transactional(readOnly = true)
+    public ContentListResponse getContentList(User user, UUID requestId) {
+        GenerationRequest request = requestRepository.findByIdAndIsDeletedFalse(requestId)
+                .orElseThrow(GenerationRequestNotFoundException::new);
+
+        if (!request.getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        List<Content> contents = contentRepository.findByGenerationRequestAndIsDeletedFalseOrderByCreatedAtDesc(request);
+
+        Set<UUID> postedContentIds = new HashSet<>();
+        if (!contents.isEmpty()) {
+            postedContentIds.addAll(contentPostRepository.findContentIdsByContentInAndStatus(contents, PublishStatus.COMPLETED));
+        }
+
+        return ContentListResponse.from(requestId, contents, postedContentIds);
+    }
+
+    @Transactional
+    public ContentResponse updateContent(String email, UUID contentId, UpdateContentRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        Content content = contentRepository.findByIdAndIsDeletedFalse(contentId)
+                .orElseThrow(ContentNotFoundException::new);
+
+        if (!content.getGenerationRequest().getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        if (request.getInstagram() != null) {
+            content.updateInstagram(request.getInstagram().getText(), request.getInstagram().getHashtags());
+        }
+        if (request.getKarrot() != null) {
+            content.updateKarrot(request.getKarrot().getText(), request.getKarrot().getHashtags());
+        }
+        if (request.getNaver() != null) {
+            content.updateNaver(request.getNaver().getText(), request.getNaver().getHashtags());
+        }
+
+        Content updated = contentRepository.saveAndFlush(content);
+        List<ContentImage> images = contentImageRepository.findByContentOrderByCreatedAtAsc(updated);
+        boolean isPosted = contentPostRepository.existsByContentAndStatus(updated, PublishStatus.COMPLETED);
+        return ContentResponse.from(updated, images, isPosted, gcsService::generateSignedUrl);
+    }
+
+    @Transactional
+    public void deleteContent(User user, UUID contentId) {
+        Content content = contentRepository.findByIdAndIsDeletedFalse(contentId)
+                .orElseThrow(ContentNotFoundException::new);
+
+        if (!content.getGenerationRequest().getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        content.delete();
+        contentRepository.save(content);
+    }
+
+    @Transactional
+    public GenerateContentResponse startRegeneration(User user, UUID contentId, RegenerateContentRequest request) {
+        Content originalContent = contentRepository.findByIdAndIsDeletedFalse(contentId)
+                .orElseThrow(ContentNotFoundException::new);
+
+        if (!originalContent.getGenerationRequest().getUser().getId().equals(user.getId())) {
+            throw new AccessDeniedToResourceException();
+        }
+
+        GenerationRequest genRequest = originalContent.getGenerationRequest();
+
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(genRequest)
+                .model(geminiConfig.getModel())
+                .status(ApiStatus.PROCESSING)
+                .build();
+
+        ApiLog savedLog = apiLogRepository.save(apiLog);
+
+        regenerateContentAsync(genRequest.getId(), originalContent.getId(), request, savedLog.getId());
+
+        return GenerateContentResponse.builder()
+                .requestId(genRequest.getId())
+                .taskId(savedLog.getId())
+                .startedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Async
+    public void regenerateContentAsync(UUID requestId, UUID originalContentId, RegenerateContentRequest regenerateRequest, UUID apiLogId) {
+        log.info("Starting background regeneration for request: {}, apiLog: {}", requestId, apiLogId);
+
+        Mono.fromCallable(() -> {
+                    return transactionTemplate.execute(status -> {
+                        Content originalContent = contentRepository.findById(originalContentId).orElseThrow();
+
+                        return GeminiRegenerationRequest.builder()
+                                .originalInstagramText(originalContent.getInstagramText())
+                                .originalKarrotText(originalContent.getKarrotText())
+                                .originalNaverText(originalContent.getNaverText())
+                                .feedback(regenerateRequest.getFeedback())
+                                .targets(regenerateRequest.getTargets())
+                                .build();
+                    });
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMap(geminiService::generateProcessedRegenerationContent)
+                .publishOn(Schedulers.boundedElastic())
+                .doOnNext(parsed -> {
+                    transactionTemplate.execute(status -> {
+                        ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
+                        GenerationRequest request = requestRepository.findById(requestId).orElseThrow();
+                        Content originalContent = contentRepository.findById(originalContentId).orElseThrow();
+
+                        // Merge with original content (Only update target platforms)
+                        List<String> targets = regenerateRequest.getTargets();
+                        Content newContent = Content.builder()
+                                .generationRequest(request)
+                                .instagramText(targets.contains("INSTAGRAM") && parsed.getText() != null ? parsed.getText() : originalContent.getInstagramText())
+                                .instagramHashtags(targets.contains("INSTAGRAM") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getInstagramHashtags())
+                                .karrotText(targets.contains("KARROT") && parsed.getText() != null ? parsed.getText() : originalContent.getKarrotText())
+                                .karrotTags(targets.contains("KARROT") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getKarrotTags())
+                                .naverText(targets.contains("NAVER") && parsed.getText() != null ? parsed.getText() : originalContent.getNaverText())
+                                .naverKeywords(targets.contains("NAVER") && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getNaverKeywords())
+                                .generationType(GenerationType.TEXT_ONLY)
+                                .aiModel(apiLog.getModel())
+                                .createdAt(LocalDateTime.now())
+                                .updatedAt(LocalDateTime.now())
+                                .build();
+
+                        Content savedContent = contentRepository.save(newContent);
+
+                        // Reuse images from original content
+                        List<ContentImage> originalImages = contentImageRepository.findByContentOrderByCreatedAtAsc(originalContent);
+                        for (ContentImage originalImg : originalImages) {
+                            ContentImage newImg = ContentImage.builder()
+                                    .content(savedContent)
+                                    .inputImage(originalImg.getInputImage())
+                                    .url(originalImg.getUrl())
+                                    .build();
+                            contentImageRepository.save(newImg);
+                        }
+
+                        // Update ApiLog with Metadata
+                        Integer inputTokens = parsed.getInputTokens();
+                        Integer outputTokens = parsed.getOutputTokens();
+                        BigDecimal costUsd = calculateCost(inputTokens, outputTokens);
+                        Integer responseTimeMs = parsed.getResponseTimeMs() != null ? parsed.getResponseTimeMs().intValue() : null;
+
+                        apiLog.completeSuccess(savedContent, inputTokens, outputTokens, costUsd, responseTimeMs);
+                        apiLogRepository.save(apiLog);
+                        return null;
+                    });
+                })
+                .doOnError(e -> {
+                    log.error("Error during background regeneration for apiLog {}: {}", apiLogId, e.getMessage(), e);
+                    transactionTemplate.execute(status -> {
+                        ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
+                        apiLog.completeError(e.getMessage());
+                        apiLogRepository.save(apiLog);
+                        return null;
+                    });
+                })
+                .subscribe();
+    }
+
+    private BigDecimal calculateCost(Integer inputTokens, Integer outputTokens) {
+        if (inputTokens == null || outputTokens == null) return null;
+
+        // Cost calculation ($0.50 per 1M input, $3.00 per 1M output)
+        BigDecimal inputCost = BigDecimal.valueOf(inputTokens)
+                .multiply(new BigDecimal("0.50"))
+                .divide(new BigDecimal("1000000"), 10, RoundingMode.HALF_UP);
+        BigDecimal outputCost = BigDecimal.valueOf(outputTokens)
+                .multiply(new BigDecimal("3.00"))
+                .divide(new BigDecimal("1000000"), 10, RoundingMode.HALF_UP);
+        return inputCost.add(outputCost);
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
@@ -154,10 +154,11 @@ public class ContentService {
 
                         // Save ContentImages (map from input images)
                         for (InputImage inputImage : inputImages) {
+                            String snapshotUrl = gcsService.copyFile(inputImage.getUrl(), "contents");
                             ContentImage contentImage = ContentImage.builder()
                                     .content(savedContent)
-                                    .inputImage(inputImage)
-                                    .url(inputImage.getUrl())
+                                    .inputImageId(inputImage.getId())
+                                    .url(snapshotUrl)
                                     .build();
                             contentImageRepository.save(contentImage);
                         }
@@ -357,7 +358,7 @@ public class ContentService {
                         for (ContentImage originalImg : originalImages) {
                             ContentImage newImg = ContentImage.builder()
                                     .content(savedContent)
-                                    .inputImage(originalImg.getInputImage())
+                                    .inputImageId(originalImg.getInputImageId())
                                     .url(originalImg.getUrl())
                                     .build();
                             contentImageRepository.save(newImg);

--- a/backend-spring/today-store/src/main/resources/application.yml
+++ b/backend-spring/today-store/src/main/resources/application.yml
@@ -81,3 +81,7 @@ app:
     prefix: ${GCS_PREFIX:uploads/}
     signed-url-enabled: ${SIGNED_URL_ENABLED:false}
     signed-url-duration-minutes: ${SIGNED_URL_DURATION_MINUTES:15}
+  gemini:
+    api-key: ${GEMINI_API_KEY}
+    model: "gemini-3-flash-preview"
+    endpoint: "https://generativelanguage.googleapis.com/v1beta/models"

--- a/backend-spring/today-store/src/main/resources/db/migration/V4__remove_fk_from_content_images.sql
+++ b/backend-spring/today-store/src/main/resources/db/migration/V4__remove_fk_from_content_images.sql
@@ -1,0 +1,3 @@
+-- V4__remove_fk_from_content_images.sql
+
+ALTER TABLE content_images DROP CONSTRAINT IF EXISTS fk_content_images_input_image;

--- a/backend-spring/today-store/src/test/resources/application.yml
+++ b/backend-spring/today-store/src/test/resources/application.yml
@@ -64,3 +64,7 @@ app:
   gcs:
     bucket: test-bucket
     prefix: uploads/
+  gemini:
+    api-key: test_gemini_key
+    model: "gemini-3-flash-preview"
+    endpoint: "https://generativelanguage.googleapis.com/v1beta/models"


### PR DESCRIPTION
## Issue Number
closed #38 

## As-Is
- AI 컨텐츠 생성을 위해 백엔드 프로젝트 <-> Gemini API 간 연동 필요
- 사전에 설계되었던 Gemini API를 활용한 컨텐츠 관리 API의 서비스, 엔드포인트 정의 필요
- 기존 ContentImage 엔티티 정의에서 Input Image 엔티티를 참조하는 fk 제약 조건으로 인해 Generation Request 수정 시 사전에 생성된 content image 데이터 불일치 발생 가능성 확인

## To-Be
- Gemini API 연동
  1. 비동기, REST API 방식의 Gemini API 연동
  2. 프롬프트, 가드레일 로직 적용
  3. application.yml : Gemini 연동 설정 추가(테스트 환경의 application.yml에 동일하게 적용)
- 컨텐츠 관리 API 비즈니스 로직 구현, 엔드포인트 정의
  1. Generatino Request에 대한 컨텐츠 생성(비동기)
  2. 생성 작업(api log) polling
  3. 컨텐츠 조회
  4. 특정 Generation Request에서 생성된 모든 컨텐츠 목록 조회
  5. 컨텐츠 편집
  6. 컨텐츠 삭제(soft delete)
  7. 컨텐츠 재생성(비동기)
- Content Image 관련
  1. input image 참조하는 fk 제약 조건 제거 마이그레이션 스크립트 추가(V4)
  2. content image 엔티티 생성 시, input image 참조 대신 GCS에 파일을 복사하여 복사된 파일 참조하도록 수정.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
