### PR TITLE
[Fix] Gemini 에러 노출 차단 및 재생성 API 입력 검증 보강

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/common/config/GeminiConfig.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/config/GeminiConfig.java
@@ -46,7 +46,7 @@ public class GeminiConfig {
     }
 
     public String getGenerateUrl() {
-        return String.format("%s/%s:generateContent?key=%s", endpoint, model, apiKey);
+        return String.format("%s/%s:generateContent", endpoint, model);
     }
 
 }

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
 
     // AI / Gemini
     AI_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "AI001", "Gemini returned empty response"),
-    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI002", "Failed to parse AI response");
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI002", "Failed to parse AI response"),
+    AI_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "AI003", "AI generation request failed. Please try again later.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ValidationErrorResolver.java
@@ -16,6 +16,7 @@ public class ValidationErrorResolver {
         errorMapping.put("createGenerationRequest", ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
         errorMapping.put("pageRequest", ErrorCode.INVALID_PAGE_PARAM);
         errorMapping.put("updateGenerationRequest", ErrorCode.GENERATION_REQUEST_REQUIRED_FIELDS_MISSING);
+        errorMapping.put("regenerateContentRequest", ErrorCode.INVALID_REGENERATION_REQUEST);
 
     }
 

--- a/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/gemini/service/GeminiService.java
@@ -60,6 +60,7 @@ public class GeminiService {
         long startTime = System.currentTimeMillis();
         return webClient.post()
                 .uri(url)
+                .headers(headers -> headers.set("x-goog-api-key", geminiConfig.getApiKey()))
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/RegenerateContentRequest.java
@@ -1,13 +1,11 @@
 package today_store.content.content.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @Builder
@@ -21,5 +19,9 @@ RegenerateContentRequest {
     private boolean regenerateImage;
 
     @NotBlank(message = "Target platform is required")
+    @Pattern(
+            regexp = "INSTAGRAM|KARROT|NAVER",
+            message = "Target platform must be one of INSTAGRAM, KARROT, NAVER"
+    )
     private String target;
 }

--- a/backend-spring/today-store/src/main/java/today_store/content/content/dto/TargetPlatform.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/dto/TargetPlatform.java
@@ -1,0 +1,17 @@
+package today_store.content.content.dto;
+
+import today_store.content.content.exception.InvalidRegenerationRequestException;
+
+public enum TargetPlatform {
+    INSTAGRAM,
+    KARROT,
+    NAVER;
+
+    public static TargetPlatform from(String value) {
+        try {
+            return TargetPlatform.valueOf(value);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new InvalidRegenerationRequestException();
+        }
+    }
+}

--- a/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
+++ b/backend-spring/today-store/src/main/java/today_store/content/content/service/ContentService.java
@@ -7,12 +7,15 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import today_store.authentication.entity.User;
 import today_store.authentication.exception.AccessDeniedToResourceException;
 import today_store.authentication.repository.UserRepository;
 import today_store.common.config.GeminiConfig;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
 import today_store.common.gcs.GcsService;
 import today_store.common.gemini.dto.GeminiPromptRequest;
 import today_store.common.gemini.dto.GeminiRegenerationRequest;
@@ -175,10 +178,14 @@ public class ContentService {
                     });
                 })
                 .doOnError(e -> {
-                    log.error("Error during background generation for apiLog {}: {}", apiLogId, e.getMessage(), e);
+                    String safeErrorMessage = toSafeTaskErrorMessage(e);
+                    log.error("Error during background generation for apiLog {} [{}]: {}",
+                            apiLogId,
+                            Exceptions.unwrap(e).getClass().getSimpleName(),
+                            safeErrorMessage);
                     transactionTemplate.execute(status -> {
                         ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
-                        apiLog.completeError(e.getMessage());
+                        apiLog.completeError(safeErrorMessage);
                         apiLogRepository.save(apiLog);
                         return null;
                     });
@@ -290,6 +297,7 @@ public class ContentService {
             throw new AccessDeniedToResourceException();
         }
 
+        TargetPlatform.from(request.getTarget());
         GenerationRequest genRequest = originalContent.getGenerationRequest();
 
         ApiLog apiLog = ApiLog.builder()
@@ -319,26 +327,23 @@ public class ContentService {
 
                         String originalText;
                         List<String> originalHashtags;
-                        String target = regenerateRequest.getTarget();
-                        if ("INSTAGRAM".equals(target)) {
+                        TargetPlatform targetPlatform = TargetPlatform.from(regenerateRequest.getTarget());
+                        if (targetPlatform == TargetPlatform.INSTAGRAM) {
                             originalText = originalContent.getInstagramText();
                             originalHashtags = originalContent.getInstagramHashtags();
-                        } else if ("KARROT".equals(target)) {
+                        } else if (targetPlatform == TargetPlatform.KARROT) {
                             originalText = originalContent.getKarrotText();
                             originalHashtags = originalContent.getKarrotTags();
-                        } else if ("NAVER".equals(target)) {
+                        } else {
                             originalText = originalContent.getNaverText();
                             originalHashtags = originalContent.getNaverKeywords();
-                        } else {
-                            originalText = "";
-                            originalHashtags = List.of();
                         }
 
                         return GeminiRegenerationRequest.builder()
                                 .originalText(originalText)
                                 .originalHashtags(originalHashtags)
                                 .feedback(regenerateRequest.getFeedback())
-                                .target(target)
+                                .target(targetPlatform.name())
                                 .build();
                     });
                 })
@@ -352,15 +357,15 @@ public class ContentService {
                         Content originalContent = contentRepository.findById(originalContentId).orElseThrow();
 
                         // Merge with original content (Only update target platform)
-                        String target = regenerateRequest.getTarget();
+                        TargetPlatform targetPlatform = TargetPlatform.from(regenerateRequest.getTarget());
                         Content newContent = Content.builder()
                                 .generationRequest(request)
-                                .instagramText("INSTAGRAM".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getInstagramText())
-                                .instagramHashtags("INSTAGRAM".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getInstagramHashtags())
-                                .karrotText("KARROT".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getKarrotText())
-                                .karrotTags("KARROT".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getKarrotTags())
-                                .naverText("NAVER".equals(target) && parsed.getText() != null ? parsed.getText() : originalContent.getNaverText())
-                                .naverKeywords("NAVER".equals(target) && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getNaverKeywords())
+                                .instagramText(targetPlatform == TargetPlatform.INSTAGRAM && parsed.getText() != null ? parsed.getText() : originalContent.getInstagramText())
+                                .instagramHashtags(targetPlatform == TargetPlatform.INSTAGRAM && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getInstagramHashtags())
+                                .karrotText(targetPlatform == TargetPlatform.KARROT && parsed.getText() != null ? parsed.getText() : originalContent.getKarrotText())
+                                .karrotTags(targetPlatform == TargetPlatform.KARROT && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getKarrotTags())
+                                .naverText(targetPlatform == TargetPlatform.NAVER && parsed.getText() != null ? parsed.getText() : originalContent.getNaverText())
+                                .naverKeywords(targetPlatform == TargetPlatform.NAVER && parsed.getHashtags() != null ? parsed.getHashtags() : originalContent.getNaverKeywords())
                                 .generationType(GenerationType.TEXT_ONLY)
                                 .aiModel(apiLog.getModel())
                                 .createdAt(LocalDateTime.now())
@@ -370,6 +375,7 @@ public class ContentService {
                         Content savedContent = contentRepository.save(newContent);
 
                         // Reuse images from original content
+                        // TODO: regenerateImage=true가 아직 미구현 상태
                         List<ContentImage> originalImages = contentImageRepository.findByContentOrderByCreatedAtAsc(originalContent);
                         for (ContentImage originalImg : originalImages) {
                             ContentImage newImg = ContentImage.builder()
@@ -392,15 +398,27 @@ public class ContentService {
                     });
                 })
                 .doOnError(e -> {
-                    log.error("Error during background regeneration for apiLog {}: {}", apiLogId, e.getMessage(), e);
+                    String safeErrorMessage = toSafeTaskErrorMessage(e);
+                    log.error("Error during background regeneration for apiLog {} [{}]: {}",
+                            apiLogId,
+                            Exceptions.unwrap(e).getClass().getSimpleName(),
+                            safeErrorMessage);
                     transactionTemplate.execute(status -> {
                         ApiLog apiLog = apiLogRepository.findById(apiLogId).orElseThrow();
-                        apiLog.completeError(e.getMessage());
+                        apiLog.completeError(safeErrorMessage);
                         apiLogRepository.save(apiLog);
                         return null;
                     });
                 })
                 .subscribe();
+    }
+
+    String toSafeTaskErrorMessage(Throwable throwable) {
+        Throwable cause = Exceptions.unwrap(throwable);
+        if (cause instanceof CustomException customException) {
+            return customException.getErrorCode().getMessage();
+        }
+        return ErrorCode.AI_REQUEST_FAILED.getMessage();
     }
 
     private BigDecimal calculateCost(Integer inputTokens, Integer outputTokens) {

--- a/backend-spring/today-store/src/test/java/today_store/common/gemini/service/GeminiServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/gemini/service/GeminiServiceTest.java
@@ -1,0 +1,88 @@
+package today_store.common.gemini.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import today_store.common.config.GeminiConfig;
+import today_store.common.gemini.dto.GeminiResponse;
+
+@DisplayName("Gemini 서비스 테스트")
+class GeminiServiceTest {
+
+    private AtomicReference<ClientRequest> capturedRequest;
+
+    private GeminiService geminiService;
+
+    @BeforeEach
+    void setUp() {
+        capturedRequest = new AtomicReference<>();
+        geminiService = new GeminiService(createGeminiConfig(), createWebClient(), new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("Gemini 요청 헤더 전송")
+    void shouldSendApiKeyViaHeaderWithoutQueryString() {
+        // Gemini 요청을 보내면 API key를 URL query string이 아니라 x-goog-api-key 헤더로만 전달해야 한다.
+
+        // given
+        GeminiResponse response = geminiService.generateContent("prompt", List.of("https://signed.example.com/image.png")).block();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getText()).isEqualTo("ok");
+        assertThat(capturedRequest.get()).isNotNull();
+        assertThat(capturedRequest.get().url().toString())
+                .isEqualTo("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent")
+                .doesNotContain("key=")
+                .doesNotContain("test-secret-key");
+        assertThat(capturedRequest.get().headers().getFirst("x-goog-api-key")).isEqualTo("test-secret-key");
+    }
+
+    private WebClient createWebClient() {
+        ExchangeFunction exchangeFunction = request -> {
+            capturedRequest.set(request);
+            return Mono.just(ClientResponse.create(HttpStatus.OK)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .body("""
+                            {
+                              "candidates": [
+                                {
+                                  "content": {
+                                    "parts": [
+                                      {"text": "ok"}
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                            """)
+                    .build());
+        };
+
+        return WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+    }
+
+    private GeminiConfig createGeminiConfig() {
+        GeminiConfig geminiConfig = new GeminiConfig();
+        ReflectionTestUtils.setField(geminiConfig, "apiKey", "test-secret-key");
+        ReflectionTestUtils.setField(geminiConfig, "model", "gemini-2.5-flash");
+        ReflectionTestUtils.setField(geminiConfig, "endpoint", "https://generativelanguage.googleapis.com/v1beta/models");
+        return geminiConfig;
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/content/controller/ContentControllerWebMvcTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/controller/ContentControllerWebMvcTest.java
@@ -1,0 +1,165 @@
+package today_store.content.content.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import today_store.authentication.entity.User;
+import today_store.common.exception.ValidationErrorResolver;
+import today_store.common.ratelimit.RateLimitService;
+import today_store.common.ratelimit.RateLimitTier;
+import today_store.content.content.dto.GenerateContentResponse;
+import today_store.content.content.service.ContentService;
+import today_store.user.service.UserService;
+
+@WebMvcTest(controllers = ContentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ValidationErrorResolver.class)
+@DisplayName("콘텐츠 컨트롤러 테스트")
+class ContentControllerWebMvcTest {
+
+    private static final String CLIENT_IP = "203.0.113.30";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ContentService contentService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @BeforeEach
+    void setUp() {
+        given(rateLimitService.tryConsume(anyString(), any(RateLimitTier.class))).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 재생성 성공")
+    void shouldRegenerateContentWhenRequestIsValid() throws Exception {
+        // 유효한 재생성 요청이 오면 202 응답과 함께 생성 요청 ID, 작업 ID, 시작 시각을 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID contentId = UUID.randomUUID();
+        UUID requestId = UUID.randomUUID();
+        UUID taskId = UUID.randomUUID();
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 13, 15, 0);
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .requestId(requestId)
+                .taskId(taskId)
+                .startedAt(startedAt)
+                .build();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(contentService.startRegeneration(eq(user), eq(contentId), any())).willReturn(response);
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+                "feedback", "톤을 조금 더 친근하게 바꿔줘",
+                "regenerateImage", true,
+                "target", "INSTAGRAM"
+        ));
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{contentId}/regenerate", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(202);
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("taskId").asText()).isEqualTo(taskId.toString());
+        then(userService).should().getUser(any(Authentication.class));
+        then(contentService).should().startRegeneration(
+                eq(user),
+                eq(contentId),
+                argThat(request ->
+                        request.getFeedback().equals("톤을 조금 더 친근하게 바꿔줘")
+                                && request.isRegenerateImage()
+                                && request.getTarget().equals("INSTAGRAM"))
+        );
+    }
+
+    @Test
+    @DisplayName("재생성 target 검증 실패")
+    void shouldReturnBadRequestWhenTargetPlatformIsInvalid() throws Exception {
+        // 허용되지 않은 target 값으로 재생성을 요청하면 C006 검증 오류와 함께 400 응답을 반환해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+                "feedback", "문구를 수정해줘",
+                "regenerateImage", false,
+                "target", "YOUTUBE"
+        ));
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{contentId}/regenerate", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("C006");
+        assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("target");
+        then(userService).should(never()).getUser(any(Authentication.class));
+        then(contentService).should(never()).startRegeneration(any(), any(), any());
+    }
+
+    private JsonNode readBody(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken() {
+        return new UsernamePasswordAuthenticationToken(
+                "user@example.com",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private User createUser(String email) {
+        User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        return user;
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/content/service/ContentServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/service/ContentServiceTest.java
@@ -1,0 +1,211 @@
+package today_store.content.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
+import today_store.authentication.entity.User;
+import today_store.authentication.repository.UserRepository;
+import today_store.common.config.GeminiConfig;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gcs.GcsService;
+import today_store.common.gemini.service.GeminiService;
+import today_store.content.content.dto.RegenerateContentRequest;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.GenerationType;
+import today_store.content.content.exception.InvalidRegenerationRequestException;
+import today_store.content.content.repository.ApiLogRepository;
+import today_store.content.content.repository.ContentImageRepository;
+import today_store.content.content.repository.ContentPostRepository;
+import today_store.content.content.repository.ContentRepository;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.repository.GenerationRequestRepository;
+import today_store.content.request.repository.InputImageRepository;
+import today_store.store.repository.StoreRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("콘텐츠 서비스 테스트")
+class ContentServiceTest {
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    @Mock
+    private ContentImageRepository contentImageRepository;
+
+    @Mock
+    private ApiLogRepository apiLogRepository;
+
+    @Mock
+    private GenerationRequestRepository requestRepository;
+
+    @Mock
+    private InputImageRepository inputImageRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ContentPostRepository contentPostRepository;
+
+    @Mock
+    private GeminiService geminiService;
+
+    @Mock
+    private GcsService gcsService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @Mock
+    private GeminiConfig geminiConfig;
+
+    private TestableContentService contentService;
+
+    @BeforeEach
+    void setUp() {
+        contentService = new TestableContentService(
+                contentRepository,
+                contentImageRepository,
+                apiLogRepository,
+                requestRepository,
+                inputImageRepository,
+                storeRepository,
+                userRepository,
+                contentPostRepository,
+                geminiService,
+                gcsService,
+                transactionTemplate,
+                geminiConfig
+        );
+    }
+
+    @Test
+    @DisplayName("재생성 target 사전 차단")
+    void shouldRejectInvalidTargetBeforeSavingApiLog() {
+        // 지원하지 않는 target 값으로 재생성을 요청하면 ApiLog를 저장하지 않고 즉시 예외를 던져야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID contentId = UUID.randomUUID();
+        GenerationRequest generationRequest = GenerationRequest.builder()
+                .user(user)
+                .concept("봄 프로모션")
+                .build();
+        ReflectionTestUtils.setField(generationRequest, "id", UUID.randomUUID());
+
+        Content originalContent = Content.builder()
+                .generationRequest(generationRequest)
+                .generationType(GenerationType.ALL)
+                .build();
+        ReflectionTestUtils.setField(originalContent, "id", contentId);
+
+        given(contentRepository.findByIdAndIsDeletedFalse(contentId)).willReturn(Optional.of(originalContent));
+
+        RegenerateContentRequest request = RegenerateContentRequest.builder()
+                .feedback("문구를 바꿔줘")
+                .regenerateImage(true)
+                .target("YOUTUBE")
+                .build();
+
+        // when
+        InvalidRegenerationRequestException exception = assertThrows(
+                InvalidRegenerationRequestException.class,
+                () -> contentService.startRegeneration(user, contentId, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REGENERATION_REQUEST);
+        assertThat(contentService.regenerateAsyncCalled).isFalse();
+        then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 메시지 치환")
+    void shouldSanitizeUnexpectedTaskErrors() {
+        // 예상치 못한 예외가 발생하면 원본 URL, key 파라미터 같은 민감한 값을 제거한 안전한 메시지만 반환해야 한다.
+
+        // given
+        String safeMessage = contentService.toSafeTaskErrorMessage(
+                new RuntimeException("Gemini request failed: https://example.test?key=secret-value")
+        );
+
+        // then
+        assertThat(safeMessage).isEqualTo(ErrorCode.AI_REQUEST_FAILED.getMessage());
+        assertThat(safeMessage).doesNotContain("secret-value").doesNotContain("key=");
+    }
+
+    @Test
+    @DisplayName("CustomException 메시지 유지")
+    void shouldKeepKnownCustomExceptionMessage() {
+        // 프로젝트에서 정의한 CustomException은 기존의 안전한 에러 메시지를 그대로 유지해야 한다.
+
+        // given
+        String safeMessage = contentService.toSafeTaskErrorMessage(new CustomException(ErrorCode.AI_PARSE_ERROR));
+
+        // then
+        assertThat(safeMessage).isEqualTo(ErrorCode.AI_PARSE_ERROR.getMessage());
+    }
+
+    private User createUser(String email) {
+        User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        return user;
+    }
+
+    private static class TestableContentService extends ContentService {
+        private boolean regenerateAsyncCalled;
+
+        TestableContentService(
+                ContentRepository contentRepository,
+                ContentImageRepository contentImageRepository,
+                ApiLogRepository apiLogRepository,
+                GenerationRequestRepository requestRepository,
+                InputImageRepository inputImageRepository,
+                StoreRepository storeRepository,
+                UserRepository userRepository,
+                ContentPostRepository contentPostRepository,
+                GeminiService geminiService,
+                GcsService gcsService,
+                TransactionTemplate transactionTemplate,
+                GeminiConfig geminiConfig
+        ) {
+            super(
+                    contentRepository,
+                    contentImageRepository,
+                    apiLogRepository,
+                    requestRepository,
+                    inputImageRepository,
+                    storeRepository,
+                    userRepository,
+                    contentPostRepository,
+                    geminiService,
+                    gcsService,
+                    transactionTemplate,
+                    geminiConfig
+            );
+        }
+
+        @Override
+        public void regenerateContentAsync(UUID requestId, UUID originalContentId, RegenerateContentRequest regenerateRequest, UUID apiLogId) {
+            regenerateAsyncCalled = true;
+        }
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #49 

## As-Is
- 기존에는 Gemini API key가 요청 URL query string에 포함되어 노출 위험이 존재
- 비동기 생성/재생성 실패 시 raw upstream exception message가 ApiLog와 task status 응답에 그대로 반영
- 재생성 API는 target 값에 대한 제약이 없어 잘못된 값도 요청 가능

## To-Be
- Gemini API key를 URL이 아닌 request header로 전달하도록 변경
- 비동기 실패 메시지는 sanitized message만 저장/응답하도록 수정
- 재생성 target은 INSTAGRAM, KARROT, NAVER만 허용하도록 검증을 추가
- invalid target 요청은 ApiLog 생성 전에 차단되도록 보강
- 관련 회귀 테스트를 추가


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- regenerateImage에 TODO 주석 추가