### PR TITLE
[Test] Gemini 연동 및 콘텐츠 관리 API 테스트 코드 작성

### DIFF
--- a/backend-spring/today-store/src/test/java/today_store/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/exception/GlobalExceptionHandlerTest.java
@@ -21,6 +21,10 @@ import today_store.store.dto.CreateStoreRequest;
 import today_store.store.exception.StoreAlreadyExistException;
 import today_store.store.exception.StoreNotFoundException;
 import today_store.user.dto.UpdateUserProfileRequest;
+import today_store.content.content.dto.RegenerateContentRequest;
+import today_store.content.content.exception.ContentNotFoundException;
+import today_store.content.content.exception.InvalidRegenerationRequestException;
+import today_store.content.content.exception.TaskNotFoundException;
 import today_store.content.request.dto.CreateGenerationRequest;
 import today_store.content.request.dto.UpdateGenerationRequest;
 import today_store.content.request.exception.FileNameMismatchException;
@@ -399,6 +403,95 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getMessage()).isEqualTo("Store profile not found");
     }
 
+    @Test
+    @DisplayName("재생성 요청 검증 오류를 C006 응답으로 변환")
+    void shouldResolveRegenerateContentValidationErrorCode() throws Exception {
+        // regenerateContentRequest 검증 실패는 C006 코드로 응답해야 한다.
+
+        // given
+        Method method = ValidationFixture.class.getDeclaredMethod("handleRegenerateContent", RegenerateContentRequest.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(
+                RegenerateContentRequest.builder().feedback("retry").target("YOUTUBE").build(),
+                "regenerateContentRequest"
+        );
+        bindingResult.addError(new FieldError(
+                "regenerateContentRequest",
+                "target",
+                "YOUTUBE",
+                false,
+                null,
+                null,
+                "Target platform must be one of INSTAGRAM, KARROT, NAVER"
+        ));
+        MethodArgumentNotValidException exception = new MethodArgumentNotValidException(methodParameter, bindingResult);
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleMethodArgumentNotValidException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C006");
+        assertThat(response.getBody().getMessage()).isEqualTo("Empty feedback or Invalid target platform");
+        assertThat(response.getBody().getErrors()).hasSize(1);
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("target");
+    }
+
+    @Test
+    @DisplayName("잘못된 재생성 요청 예외를 C006 응답으로 변환")
+    void shouldHandleInvalidRegenerationRequestException() {
+        // InvalidRegenerationRequestException은 C006 응답으로 내려가야 한다.
+
+        // given
+        InvalidRegenerationRequestException exception = new InvalidRegenerationRequestException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C006");
+        assertThat(response.getBody().getMessage()).isEqualTo("Empty feedback or Invalid target platform");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 없음 예외를 C007 응답으로 변환")
+    void shouldHandleContentNotFoundException() {
+        // ContentNotFoundException은 C007 응답으로 변환되어야 한다.
+
+        // given
+        ContentNotFoundException exception = new ContentNotFoundException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("C007");
+        assertThat(response.getBody().getMessage()).isEqualTo("Content not found or already deleted");
+    }
+
+    @Test
+    @DisplayName("작업 없음 예외를 G002 응답으로 변환")
+    void shouldHandleTaskNotFoundException() {
+        // TaskNotFoundException은 G002 응답으로 변환되어야 한다.
+
+        // given
+        TaskNotFoundException exception = new TaskNotFoundException();
+
+        // when
+        ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleCustomException(exception);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("G002");
+        assertThat(response.getBody().getMessage()).isEqualTo("Task ID not found");
+    }
+
     private static class ValidationFixture {
 
         public void handle(@Valid LoginRequest loginRequest) {
@@ -414,6 +507,9 @@ class GlobalExceptionHandlerTest {
         }
 
         public void handleUpdateGeneration(@Valid UpdateGenerationRequest updateGenerationRequest) {
+        }
+
+        public void handleRegenerateContent(@Valid RegenerateContentRequest regenerateContentRequest) {
         }
 
         public void handlePageRequest(@Valid PageRequest pageRequest) {

--- a/backend-spring/today-store/src/test/java/today_store/common/gcs/GcsServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/gcs/GcsServiceTest.java
@@ -139,6 +139,62 @@ class GcsServiceTest {
     }
 
     @Test
+    @DisplayName("이미지 복사 성공")
+    void shouldCopyFileInGcs() {
+        // copy 요청이 들어오면 source와 target이 올바른 CopyRequest로 구성되어야 한다.
+
+        // given
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+
+        // when
+        String copiedObjectName = gcsService.copyFile("2026/04/14/requests/sample.png", "contents");
+
+        // then
+        assertThat(copiedObjectName).matches("^" + datePath + "/contents/[0-9a-f\\-]+_sample\\.png$");
+
+        ArgumentCaptor<Storage.CopyRequest> copyRequestCaptor = ArgumentCaptor.forClass(Storage.CopyRequest.class);
+        then(storage).should().copy(copyRequestCaptor.capture());
+        assertThat(copyRequestCaptor.getValue().getSource().getBucket()).isEqualTo("test-bucket");
+        assertThat(copyRequestCaptor.getValue().getSource().getName()).isEqualTo("2026/04/14/requests/sample.png");
+        assertThat(copyRequestCaptor.getValue().getTarget().getBlobId().getBucket()).isEqualTo("test-bucket");
+        assertThat(copyRequestCaptor.getValue().getTarget().getBlobId().getName()).isEqualTo(copiedObjectName);
+    }
+
+    @Test
+    @DisplayName("이미지 복사 입력값 비어 있음")
+    void shouldReturnNullWhenCopySourceIsBlank() {
+        // source object가 비어 있으면 copy를 시도하지 않고 null을 반환해야 한다.
+
+        // when
+        String nullResult = gcsService.copyFile(null, "contents");
+        String blankResult = gcsService.copyFile("", "contents");
+
+        // then
+        assertThat(nullResult).isNull();
+        assertThat(blankResult).isNull();
+        then(storage).should(never()).copy(any(Storage.CopyRequest.class));
+    }
+
+    @Test
+    @DisplayName("이미지 복사 실패")
+    void shouldThrowWhenCopyFails() {
+        // storage.copy 실패는 표준화된 copy 예외로 감싸야 한다.
+
+        // given
+        given(storage.copy(any(Storage.CopyRequest.class))).willThrow(new RuntimeException("copy failed"));
+
+        // when
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> gcsService.copyFile("2026/04/14/requests/sample.png", "contents")
+        );
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("GCS copy failed");
+        assertThat(exception.getCause()).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
     @DisplayName("이미지 삭제 성공")
     void shouldDeleteSanitizedObjectName() {
         // objectName이 있으면 sanitize 후 storage.delete를 호출해야 한다.

--- a/backend-spring/today-store/src/test/java/today_store/common/gemini/service/GeminiServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/gemini/service/GeminiServiceTest.java
@@ -1,9 +1,12 @@
 package today_store.common.gemini.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +21,10 @@ import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import today_store.common.config.GeminiConfig;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gemini.dto.GeminiParsedResponse;
+import today_store.common.gemini.dto.GeminiRegenerationRequest;
 import today_store.common.gemini.dto.GeminiResponse;
 
 @DisplayName("Gemini 서비스 테스트")
@@ -30,7 +37,25 @@ class GeminiServiceTest {
     @BeforeEach
     void setUp() {
         capturedRequest = new AtomicReference<>();
-        geminiService = new GeminiService(createGeminiConfig(), createWebClient(), new ObjectMapper());
+        geminiService = new GeminiService(
+                createGeminiConfig(),
+                createWebClient(jsonResponse(HttpStatus.OK, """
+                        {
+                          "candidates": [
+                            {
+                              "content": {
+                                "parts": [
+                                  {
+                                    "text": "ok"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """)),
+                new ObjectMapper()
+        );
     }
 
     @Test
@@ -52,29 +77,188 @@ class GeminiServiceTest {
         assertThat(capturedRequest.get().headers().getFirst("x-goog-api-key")).isEqualTo("test-secret-key");
     }
 
-    private WebClient createWebClient() {
+    @Test
+    @DisplayName("Gemini 응답 fenced JSON 파싱")
+    void shouldParseFencedJsonAndCopyMetadata() {
+        // fenced JSON 응답은 정상 파싱하고 usage metadata를 결과에 복사해야 한다.
+
+        // given
+        GeminiResponse response = responseWithText("""
+                ```json
+                {
+                  "photo_info": "Sunny cafe",
+                  "text": "Body copy",
+                  "hashtags": ["cafe"]
+                }
+                ```
+                """);
+        response.setUsageMetadata(new GeminiResponse.UsageMetadata(120, 45, 165));
+        response.setResponseTimeMs(987L);
+
+        // when
+        GeminiParsedResponse parsed = geminiService.processResponse(response);
+
+        // then
+        assertThat(parsed.getPhotoInfo()).isEqualTo("Sunny cafe");
+        assertThat(parsed.getText()).isEqualTo("Body copy");
+        assertThat(parsed.getHashtags()).containsExactly("#cafe");
+        assertThat(parsed.getInputTokens()).isEqualTo(120);
+        assertThat(parsed.getOutputTokens()).isEqualTo(45);
+        assertThat(parsed.getResponseTimeMs()).isEqualTo(987L);
+    }
+
+    @Test
+    @DisplayName("Gemini 해시태그 정규화")
+    void shouldNormalizeHashtagsAndRemoveTail() {
+        // 본문 마지막 줄 해시태그는 제거하고 hashtags는 중복 없이 정규화해야 한다.
+
+        // given
+        GeminiResponse response = responseWithText("""
+                {
+                  "photo_info": "Cozy cafe",
+                  "text": "Fresh coffee is ready.\\n#spring #cafe #spring",
+                  "hashtags": [" spring", "#cafe", "", null, "spring"]
+                }
+                """);
+
+        // when
+        GeminiParsedResponse parsed = geminiService.processResponse(response);
+
+        // then
+        assertThat(parsed.getText()).isEqualTo("Fresh coffee is ready.");
+        assertThat(parsed.getHashtags()).containsExactly("#spring", "#cafe");
+    }
+
+    @Test
+    @DisplayName("Gemini 본문 줄바꿈 정리")
+    void shouldSoftWrapLongSingleLineText() {
+        // 단일 줄의 여러 문장은 문장 기준으로 줄바꿈을 추가해 가독성을 높여야 한다.
+
+        // given
+        GeminiResponse response = responseWithText("""
+                {
+                  "photo_info": "Cafe",
+                  "text": "First sentence. Second sentence! Third sentence?",
+                  "hashtags": []
+                }
+                """);
+
+        // when
+        GeminiParsedResponse parsed = geminiService.processResponse(response);
+
+        // then
+        assertThat(parsed.getText()).isEqualTo("First sentence.\nSecond sentence!\nThird sentence?");
+    }
+
+    @Test
+    @DisplayName("Gemini 빈 응답 예외")
+    void shouldThrowWhenResponseTextIsEmpty() {
+        // Gemini 응답 본문이 비어 있으면 AI001 예외를 반환해야 한다.
+
+        // given
+        GeminiResponse response = GeminiResponse.builder().candidates(List.of()).build();
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> geminiService.processResponse(response));
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AI_RESPONSE_EMPTY);
+    }
+
+    @Test
+    @DisplayName("Gemini JSON 파싱 예외")
+    void shouldThrowWhenJsonParsingFails() {
+        // 응답 JSON 파싱에 실패하면 AI002 예외를 반환해야 한다.
+
+        // given
+        GeminiResponse response = responseWithText("not-json");
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> geminiService.processResponse(response));
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AI_PARSE_ERROR);
+    }
+
+    @Test
+    @DisplayName("Gemini 재생성 응답 후처리")
+    void shouldProcessRegenerationContent() {
+        // 재생성 응답도 동일한 후처리 파이프라인을 거쳐 본문과 해시태그를 정리해야 한다.
+
+        // given
+        geminiService = new GeminiService(createGeminiConfig(), createWebClient(jsonResponse(HttpStatus.OK, """
+                {
+                  "candidates": [
+                    {
+                      "content": {
+                        "parts": [
+                          {
+                            "text": "{\\"text\\":\\"Refined copy.\\\\n#fresh\\",\\"hashtags\\":[\\"fresh\\"]}"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "usageMetadata": {
+                    "promptTokenCount": 210,
+                    "candidatesTokenCount": 80,
+                    "totalTokenCount": 290
+                  }
+                }
+                """)), new ObjectMapper());
+
+        // when
+        GeminiParsedResponse parsed = geminiService.generateProcessedRegenerationContent(
+                GeminiRegenerationRequest.builder()
+                        .originalText("Old text")
+                        .originalHashtags(List.of("#old"))
+                        .feedback("Make it sharper")
+                        .target("INSTAGRAM")
+                        .build()
+        ).block();
+
+        // then
+        assertThat(parsed).isNotNull();
+        assertThat(parsed.getText()).isEqualTo("Refined copy.");
+        assertThat(parsed.getHashtags()).containsExactly("#fresh");
+        assertThat(parsed.getInputTokens()).isEqualTo(210);
+        assertThat(parsed.getOutputTokens()).isEqualTo(80);
+    }
+
+    private GeminiResponse responseWithText(String text) {
+        return GeminiResponse.builder()
+                .candidates(List.of(
+                        new GeminiResponse.Candidate(
+                                new GeminiResponse.Content(
+                                        List.of(new GeminiResponse.Part(text)),
+                                        "model"
+                                ),
+                                "STOP"
+                        )
+                ))
+                .build();
+    }
+
+    private WebClient createWebClient(ClientResponse... responses) {
+        Queue<ClientResponse> queue = new ArrayDeque<>(List.of(responses));
         ExchangeFunction exchangeFunction = request -> {
             capturedRequest.set(request);
-            return Mono.just(ClientResponse.create(HttpStatus.OK)
-                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .body("""
-                            {
-                              "candidates": [
-                                {
-                                  "content": {
-                                    "parts": [
-                                      {"text": "ok"}
-                                    ]
-                                  }
-                                }
-                              ]
-                            }
-                            """)
-                    .build());
+            ClientResponse response = queue.poll();
+            if (response == null) {
+                return Mono.error(new IllegalStateException("No stubbed response for request: " + request.url()));
+            }
+            return Mono.just(response);
         };
 
         return WebClient.builder()
                 .exchangeFunction(exchangeFunction)
+                .build();
+    }
+
+    private ClientResponse jsonResponse(HttpStatus status, String body) {
+        return ClientResponse.create(status)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
                 .build();
     }
 

--- a/backend-spring/today-store/src/test/java/today_store/content/content/controller/ContentControllerWebMvcTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/controller/ContentControllerWebMvcTest.java
@@ -8,6 +8,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -35,7 +38,11 @@ import today_store.authentication.entity.User;
 import today_store.common.exception.ValidationErrorResolver;
 import today_store.common.ratelimit.RateLimitService;
 import today_store.common.ratelimit.RateLimitTier;
+import today_store.content.content.dto.ContentListResponse;
+import today_store.content.content.dto.ContentResponse;
 import today_store.content.content.dto.GenerateContentResponse;
+import today_store.content.content.dto.TaskStatusResponse;
+import today_store.content.content.entity.GenerationType;
 import today_store.content.content.service.ContentService;
 import today_store.user.service.UserService;
 
@@ -65,6 +72,248 @@ class ContentControllerWebMvcTest {
     @BeforeEach
     void setUp() {
         given(rateLimitService.tryConsume(anyString(), any(RateLimitTier.class))).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 시작 성공")
+    void shouldGenerateContent() throws Exception {
+        // 콘텐츠 생성 시작 요청이 들어오면 202 응답과 requestId, taskId, startedAt을 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID taskId = UUID.randomUUID();
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 14, 13, 0);
+        GenerateContentResponse response = GenerateContentResponse.builder()
+                .requestId(requestId)
+                .taskId(taskId)
+                .startedAt(startedAt)
+                .build();
+
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(contentService.startGeneration(user, requestId)).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{requestId}/generate", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(202);
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("taskId").asText()).isEqualTo(taskId.toString());
+        assertThat(LocalDateTime.parse(body.get("startedAt").asText())).isEqualTo(startedAt);
+        then(userService).should().getUser(any(Authentication.class));
+        then(contentService).should().startGeneration(user, requestId);
+    }
+
+    @Test
+    @DisplayName("작업 상태 조회 성공")
+    void shouldReturnTaskStatus() throws Exception {
+        // 작업 상태 조회 요청이 들어오면 snake_case 필드를 포함한 상태 응답을 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID taskId = UUID.randomUUID();
+        TaskStatusResponse response = TaskStatusResponse.builder()
+                .taskId(taskId)
+                .status("error")
+                .result(null)
+                .errorMessage("AI generation request failed. Please try again later.")
+                .build();
+
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(contentService.getTaskStatus(user, taskId)).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/task/{apiLogId}", taskId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("task_id").asText()).isEqualTo(taskId.toString());
+        assertThat(body.get("status").asText()).isEqualTo("error");
+        assertThat(body.get("result").isNull()).isTrue();
+        assertThat(body.get("error_message").asText()).isEqualTo("AI generation request failed. Please try again later.");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 목록 조회 성공")
+    void shouldReturnContentList() throws Exception {
+        // 요청별 콘텐츠 목록 조회 시 요약 정보와 생성 시각을 함께 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID contentId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 14, 13, 10);
+        ContentListResponse response = ContentListResponse.builder()
+                .requestId(requestId)
+                .contents(List.of(ContentListResponse.ContentSummary.builder()
+                        .contentId(contentId)
+                        .isPosted(true)
+                        .instagramPreview("Instagram preview")
+                        .karrotPreview("Karrot preview")
+                        .naverPreview("Naver preview")
+                        .createdAt(createdAt)
+                        .build()))
+                .build();
+
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(contentService.getContentList(user, requestId)).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/{requestId}/contents", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("contents").size()).isEqualTo(1);
+        assertThat(body.get("contents").get(0).get("contentId").asText()).isEqualTo(contentId.toString());
+        assertThat(body.get("contents").get(0).get("isPosted").asBoolean()).isTrue();
+        assertThat(body.get("contents").get(0).get("instagramPreview").asText()).isEqualTo("Instagram preview");
+        assertThat(LocalDateTime.parse(body.get("contents").get(0).get("createdAt").asText())).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 상세 조회 성공")
+    void shouldReturnContentDetail() throws Exception {
+        // 콘텐츠 상세 조회 시 본문 데이터와 이미지 목록을 함께 반환해야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID contentId = UUID.randomUUID();
+        UUID imageId = UUID.randomUUID();
+        UUID inputImageId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 14, 13, 20);
+        LocalDateTime imageCreatedAt = LocalDateTime.of(2026, 4, 14, 13, 21);
+        ContentResponse response = ContentResponse.builder()
+                .id(contentId)
+                .requestId(requestId)
+                .generationType(GenerationType.ALL)
+                .isPosted(true)
+                .createdAt(createdAt)
+                .contentData(ContentResponse.ContentData.builder()
+                        .instagram(ContentResponse.PlatformData.builder().text("Instagram body").hashtags(List.of("#insta")).build())
+                        .karrot(ContentResponse.PlatformData.builder().text("Karrot body").hashtags(List.of("#karrot")).build())
+                        .naver(ContentResponse.PlatformData.builder().text("Naver body").hashtags(List.of("#naver")).build())
+                        .build())
+                .images(List.of(ContentResponse.ContentImageResponse.builder()
+                        .id(imageId)
+                        .inputImageId(inputImageId)
+                        .url("https://signed.example.com/content-1")
+                        .createdAt(imageCreatedAt)
+                        .build()))
+                .build();
+
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+        given(contentService.getContent(user, contentId)).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/{contentId}", contentId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("id").asText()).isEqualTo(contentId.toString());
+        assertThat(body.get("requestId").asText()).isEqualTo(requestId.toString());
+        assertThat(body.get("generationType").asText()).isEqualTo("ALL");
+        assertThat(body.get("isPosted").asBoolean()).isTrue();
+        assertThat(body.get("contentData").get("instagram").get("text").asText()).isEqualTo("Instagram body");
+        assertThat(body.get("contentData").get("naver").get("hashtags").get(0).asText()).isEqualTo("#naver");
+        assertThat(body.get("images").get(0).get("id").asText()).isEqualTo(imageId.toString());
+        assertThat(body.get("images").get(0).get("inputImageId").asText()).isEqualTo(inputImageId.toString());
+        assertThat(LocalDateTime.parse(body.get("images").get(0).get("createdAt").asText())).isEqualTo(imageCreatedAt);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 수정 성공")
+    void shouldUpdateContent() throws Exception {
+        // 콘텐츠 수정 요청이 들어오면 authentication 이름과 수정 본문을 서비스에 그대로 전달해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 4, 14, 13, 30);
+        ContentResponse response = ContentResponse.builder()
+                .id(contentId)
+                .requestId(UUID.randomUUID())
+                .generationType(GenerationType.ALL)
+                .isPosted(false)
+                .createdAt(createdAt)
+                .contentData(ContentResponse.ContentData.builder()
+                        .instagram(ContentResponse.PlatformData.builder().text("Updated instagram").hashtags(List.of("#new")).build())
+                        .karrot(ContentResponse.PlatformData.builder().text("Karrot body").hashtags(List.of("#karrot")).build())
+                        .naver(ContentResponse.PlatformData.builder().text("Updated naver").hashtags(List.of("#naver")).build())
+                        .build())
+                .images(List.of())
+                .build();
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+                "instagram", Map.of("text", "Updated instagram", "hashtags", List.of("#new")),
+                "naver", Map.of("text", "Updated naver")
+        ));
+
+        given(contentService.updateContent(eq("user@example.com"), eq(contentId), any())).willReturn(response);
+
+        // when
+        MvcResult result = mockMvc.perform(patch("/api/v1/contents/{contentId}", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(body.get("id").asText()).isEqualTo(contentId.toString());
+        assertThat(body.get("contentData").get("instagram").get("text").asText()).isEqualTo("Updated instagram");
+        assertThat(body.get("contentData").get("naver").get("text").asText()).isEqualTo("Updated naver");
+        then(contentService).should().updateContent(
+                eq("user@example.com"),
+                eq(contentId),
+                argThat(request ->
+                        request.getInstagram() != null
+                                && request.getInstagram().getText().equals("Updated instagram")
+                                && request.getInstagram().getHashtags().equals(List.of("#new"))
+                                && request.getNaver() != null
+                                && request.getNaver().getText().equals("Updated naver"))
+        );
+        then(userService).should(never()).getUser(any(Authentication.class));
+    }
+
+    @Test
+    @DisplayName("콘텐츠 삭제 성공")
+    void shouldDeleteContent() throws Exception {
+        // 콘텐츠 삭제 요청이 들어오면 204 응답과 함께 서비스 삭제 호출이 수행되어야 한다.
+
+        // given
+        User user = createUser("user@example.com");
+        UUID contentId = UUID.randomUUID();
+        given(userService.getUser(any(Authentication.class))).willReturn(user);
+
+        // when
+        MvcResult result = mockMvc.perform(delete("/api/v1/contents/{contentId}", contentId)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(204);
+        assertThat(result.getResponse().getContentAsString()).isBlank();
+        then(contentService).should().deleteContent(user, contentId);
     }
 
     @Test
@@ -143,6 +392,172 @@ class ContentControllerWebMvcTest {
         assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("target");
         then(userService).should(never()).getUser(any(Authentication.class));
         then(contentService).should(never()).startRegeneration(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("재생성 feedback 검증 오류")
+    void shouldReturnBadRequestWhenFeedbackIsBlank() throws Exception {
+        // feedback가 비어 있으면 C006 검증 오류를 반환해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+                "feedback", "",
+                "regenerateImage", false,
+                "target", "NAVER"
+        ));
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{contentId}/regenerate", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken()))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("C006");
+        assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("feedback");
+        then(userService).should(never()).getUser(any(Authentication.class));
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 시작 요청 제한")
+    void shouldRateLimitGenerate() throws Exception {
+        // 콘텐츠 생성 시작 엔드포인트는 HIGH 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.HIGH)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{requestId}/generate", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("작업 상태 조회 요청 제한")
+    void shouldRateLimitTaskStatus() throws Exception {
+        // 작업 상태 조회 엔드포인트는 LOW 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID taskId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.LOW)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/task/{apiLogId}", taskId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 목록 조회 요청 제한")
+    void shouldRateLimitContentList() throws Exception {
+        // 콘텐츠 목록 조회 엔드포인트는 LOW 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID requestId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.LOW)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/{requestId}/contents", requestId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 상세 조회 요청 제한")
+    void shouldRateLimitContentDetail() throws Exception {
+        // 콘텐츠 상세 조회 엔드포인트는 LOW 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.LOW)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(get("/api/v1/contents/{contentId}", contentId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 수정 요청 제한")
+    void shouldRateLimitContentUpdate() throws Exception {
+        // 콘텐츠 수정 엔드포인트는 MIDDLE 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.MIDDLE)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(patch("/api/v1/contents/{contentId}", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 삭제 요청 제한")
+    void shouldRateLimitContentDelete() throws Exception {
+        // 콘텐츠 삭제 엔드포인트는 MIDDLE 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.MIDDLE)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(delete("/api/v1/contents/{contentId}", contentId)
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
+    }
+
+    @Test
+    @DisplayName("콘텐츠 재생성 시작 요청 제한")
+    void shouldRateLimitRegeneration() throws Exception {
+        // 콘텐츠 재생성 시작 엔드포인트는 HIGH 티어 요청 제한을 적용해야 한다.
+
+        // given
+        UUID contentId = UUID.randomUUID();
+        given(rateLimitService.tryConsume(CLIENT_IP, RateLimitTier.HIGH)).willReturn(false);
+
+        // when
+        MvcResult result = mockMvc.perform(post("/api/v1/contents/{contentId}/regenerate", contentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"feedback\":\"Retry\",\"target\":\"INSTAGRAM\"}")
+                        .header("X-Forwarded-For", CLIENT_IP))
+                .andReturn();
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(429);
+        assertThat(readBody(result).get("code").asText()).isEqualTo("R001");
     }
 
     private JsonNode readBody(MvcResult result) throws Exception {

--- a/backend-spring/today-store/src/test/java/today_store/content/content/service/ContentServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/service/ContentServiceTest.java
@@ -3,38 +3,69 @@ package today_store.content.content.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
+import reactor.core.publisher.Mono;
 import today_store.authentication.entity.User;
+import today_store.authentication.exception.AccessDeniedToResourceException;
+import today_store.authentication.exception.UserNotFoundException;
 import today_store.authentication.repository.UserRepository;
 import today_store.common.config.GeminiConfig;
 import today_store.common.exception.CustomException;
 import today_store.common.exception.ErrorCode;
 import today_store.common.gcs.GcsService;
+import today_store.common.gemini.dto.GeminiParsedResponse;
+import today_store.common.gemini.dto.GeminiPromptRequest;
+import today_store.common.gemini.dto.GeminiRegenerationRequest;
 import today_store.common.gemini.service.GeminiService;
+import today_store.content.content.dto.ContentListResponse;
+import today_store.content.content.dto.ContentResponse;
+import today_store.content.content.dto.GenerateContentResponse;
 import today_store.content.content.dto.RegenerateContentRequest;
+import today_store.content.content.dto.TaskStatusResponse;
+import today_store.content.content.dto.UpdateContentRequest;
+import today_store.content.content.entity.ApiLog;
+import today_store.content.content.entity.ApiStatus;
 import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentImage;
 import today_store.content.content.entity.GenerationType;
+import today_store.content.content.entity.PublishStatus;
+import today_store.content.content.exception.ContentNotFoundException;
 import today_store.content.content.exception.InvalidRegenerationRequestException;
+import today_store.content.content.exception.TaskNotFoundException;
 import today_store.content.content.repository.ApiLogRepository;
 import today_store.content.content.repository.ContentImageRepository;
 import today_store.content.content.repository.ContentPostRepository;
 import today_store.content.content.repository.ContentRepository;
 import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+import today_store.content.request.exception.GenerationRequestNotFoundException;
 import today_store.content.request.repository.GenerationRequestRepository;
 import today_store.content.request.repository.InputImageRepository;
+import today_store.store.entity.PreferredStyle;
+import today_store.store.entity.Store;
 import today_store.store.repository.StoreRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,11 +108,19 @@ class ContentServiceTest {
     @Mock
     private GeminiConfig geminiConfig;
 
-    private TestableContentService contentService;
+    private ContentService contentService;
+    private TestableContentService testableContentService;
 
     @BeforeEach
     void setUp() {
-        contentService = new TestableContentService(
+        lenient().when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            TransactionCallback<Object> callback = invocation.getArgument(0);
+            TransactionStatus status = org.mockito.Mockito.mock(TransactionStatus.class);
+            return callback.doInTransaction(status);
+        });
+
+        contentService = new ContentService(
                 contentRepository,
                 contentImageRepository,
                 apiLogRepository,
@@ -95,6 +134,685 @@ class ContentServiceTest {
                 transactionTemplate,
                 geminiConfig
         );
+
+        testableContentService = new TestableContentService(
+                contentRepository,
+                contentImageRepository,
+                apiLogRepository,
+                requestRepository,
+                inputImageRepository,
+                storeRepository,
+                userRepository,
+                contentPostRepository,
+                geminiService,
+                gcsService,
+                transactionTemplate,
+                geminiConfig
+        );
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 시작 성공")
+    void shouldStartGeneration() {
+        // 본인 요청으로 콘텐츠 생성을 시작하면 processing ApiLog를 저장하고 비동기 작업을 시작해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        ApiLog savedLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(request));
+        given(geminiConfig.getModel()).willReturn("gemini-2.5-flash");
+        given(apiLogRepository.save(any(ApiLog.class))).willReturn(savedLog);
+
+        // when
+        GenerateContentResponse response = testableContentService.startGeneration(user, requestId);
+
+        // then
+        assertThat(response.getRequestId()).isEqualTo(requestId);
+        assertThat(response.getTaskId()).isEqualTo(apiLogId);
+        assertThat(response.getStartedAt()).isNotNull();
+        assertThat(testableContentService.generateAsyncCalled).isTrue();
+        assertThat(testableContentService.capturedRequestId).isEqualTo(requestId);
+        assertThat(testableContentService.capturedApiLogId).isEqualTo(apiLogId);
+        then(apiLogRepository).should().save(argThat(log ->
+                log.getGenerationRequest() == request
+                        && log.getModel().equals("gemini-2.5-flash")
+                        && log.getStatus() == ApiStatus.PROCESSING
+        ));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 요청 생성 시작 실패")
+    void shouldThrowWhenStartingGenerationForMissingRequest() {
+        // 생성 요청이 존재하지 않으면 ApiLog 저장 없이 예외를 반환해야 한다.
+
+        // given
+        given(requestRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> testableContentService.startGeneration(createUser("owner@example.com"), UUID.randomUUID())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+        then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("타 사용자 요청 생성 시작 거부")
+    void shouldThrowWhenStartingGenerationForAnotherUsersRequest() {
+        // 다른 사용자의 생성 요청으로 시작을 시도하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        GenerationRequest request = createGenerationRequest(owner, UUID.randomUUID());
+        given(requestRepository.findByIdAndIsDeletedFalse(request.getId())).willReturn(Optional.of(request));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> testableContentService.startGeneration(viewer, request.getId())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 비동기 성공")
+    void shouldGenerateContentAsync() throws Exception {
+        // 비동기 생성이 성공하면 Content, ContentImage, 성공 ApiLog를 모두 저장해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        UUID contentId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Store store = createStore(user);
+        InputImage firstInput = createInputImage(request, UUID.randomUUID(), "stored/input-1.png", "front", 1);
+        InputImage secondInput = createInputImage(request, UUID.randomUUID(), "stored/input-2.png", "side", 2);
+        ApiLog apiLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+        GeminiParsedResponse parsed = GeminiParsedResponse.builder()
+                .photoInfo("Bright cafe")
+                .text("Fresh drinks for spring")
+                .hashtags(List.of("#spring", "#cafe"))
+                .inputTokens(1_000)
+                .outputTokens(500)
+                .responseTimeMs(321L)
+                .build();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        given(requestRepository.findById(requestId)).willReturn(Optional.of(request));
+        given(inputImageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request)).willReturn(List.of(firstInput, secondInput));
+        given(storeRepository.findByUser(user)).willReturn(Optional.of(store));
+        given(gcsService.generateSignedUrl("stored/input-1.png")).willReturn("https://signed.example.com/input-1");
+        given(gcsService.generateSignedUrl("stored/input-2.png")).willReturn("https://signed.example.com/input-2");
+        given(geminiService.generateProcessedContent(any(GeminiPromptRequest.class))).willReturn(Mono.just(parsed));
+        given(contentRepository.save(any(Content.class))).willAnswer(invocation -> {
+            Content saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", contentId);
+            return saved;
+        });
+        given(gcsService.copyFile("stored/input-1.png", "contents")).willReturn("stored/content-1.png");
+        given(gcsService.copyFile("stored/input-2.png", "contents")).willReturn("stored/content-2.png");
+        given(contentImageRepository.save(any(ContentImage.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+        given(apiLogRepository.save(any(ApiLog.class))).willAnswer(invocation -> {
+            ApiLog saved = invocation.getArgument(0);
+            if (saved.getStatus() == ApiStatus.SUCCESS) {
+                latch.countDown();
+            }
+            return saved;
+        });
+
+        // when
+        contentService.generateContentAsync(requestId, apiLogId);
+
+        awaitLatch(latch);
+
+        // then
+        ArgumentCaptor<GeminiPromptRequest> promptCaptor = ArgumentCaptor.forClass(GeminiPromptRequest.class);
+        then(geminiService).should().generateProcessedContent(promptCaptor.capture());
+        assertThat(promptCaptor.getValue().getStoreName()).isEqualTo("Today Cafe");
+        assertThat(promptCaptor.getValue().getBusinessType()).isEqualTo("Cafe");
+        assertThat(promptCaptor.getValue().getAddress()).isEqualTo("Seoul");
+        assertThat(promptCaptor.getValue().getTargetAge()).isEqualTo("20s");
+        assertThat(promptCaptor.getValue().getTargetGender()).isEqualTo("ALL");
+        assertThat(promptCaptor.getValue().getConcept()).isEqualTo("Spring promotion");
+        assertThat(promptCaptor.getValue().getAdditionalNote()).isEqualTo("Bright mood");
+        assertThat(promptCaptor.getValue().getImageDescriptions()).containsExactly("front", "side");
+        assertThat(promptCaptor.getValue().getSignedUrls())
+                .containsExactly("https://signed.example.com/input-1", "https://signed.example.com/input-2");
+
+        ArgumentCaptor<Content> contentCaptor = ArgumentCaptor.forClass(Content.class);
+        then(contentRepository).should().save(contentCaptor.capture());
+        assertThat(contentCaptor.getValue().getGenerationRequest()).isEqualTo(request);
+        assertThat(contentCaptor.getValue().getGenerationType()).isEqualTo(GenerationType.ALL);
+        assertThat(contentCaptor.getValue().getInstagramText()).isEqualTo("Fresh drinks for spring");
+        assertThat(contentCaptor.getValue().getKarrotText()).isEqualTo("Fresh drinks for spring");
+        assertThat(contentCaptor.getValue().getNaverText()).isEqualTo("Fresh drinks for spring");
+
+        ArgumentCaptor<ContentImage> imageCaptor = ArgumentCaptor.forClass(ContentImage.class);
+        then(contentImageRepository).should(org.mockito.Mockito.times(2)).save(imageCaptor.capture());
+        assertThat(imageCaptor.getAllValues()).hasSize(2);
+        assertThat(imageCaptor.getAllValues().get(0).getInputImageId()).isEqualTo(firstInput.getId());
+        assertThat(imageCaptor.getAllValues().get(0).getUrl()).isEqualTo("stored/content-1.png");
+        assertThat(imageCaptor.getAllValues().get(1).getInputImageId()).isEqualTo(secondInput.getId());
+        assertThat(imageCaptor.getAllValues().get(1).getUrl()).isEqualTo("stored/content-2.png");
+
+        then(gcsService).should().copyFile("stored/input-1.png", "contents");
+        then(gcsService).should().copyFile("stored/input-2.png", "contents");
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        assertThat(apiLog.getContent()).isNotNull();
+        assertThat(apiLog.getContent().getId()).isEqualTo(contentId);
+        assertThat(apiLog.getInputTokens()).isEqualTo(1_000);
+        assertThat(apiLog.getOutputTokens()).isEqualTo(500);
+        assertThat(apiLog.getCostUsd()).isEqualByComparingTo("0.0020000000");
+        assertThat(apiLog.getResponseTimeMs()).isEqualTo(321);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 비동기 커스텀 예외 유지")
+    void shouldStoreCustomExceptionMessageWhenGenerateContentAsyncFails() throws Exception {
+        // 비동기 생성 중 CustomException이 발생하면 기존 에러 메시지를 그대로 ApiLog에 저장해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Store store = createStore(user);
+        InputImage input = createInputImage(request, UUID.randomUUID(), "stored/input-1.png", "front", 1);
+        ApiLog apiLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        given(requestRepository.findById(requestId)).willReturn(Optional.of(request));
+        given(inputImageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request)).willReturn(List.of(input));
+        given(storeRepository.findByUser(user)).willReturn(Optional.of(store));
+        given(gcsService.generateSignedUrl("stored/input-1.png")).willReturn("https://signed.example.com/input-1");
+        given(geminiService.generateProcessedContent(any(GeminiPromptRequest.class)))
+                .willReturn(Mono.error(new CustomException(ErrorCode.AI_PARSE_ERROR)));
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+        given(apiLogRepository.save(any(ApiLog.class))).willAnswer(invocation -> {
+            ApiLog saved = invocation.getArgument(0);
+            if (saved.getStatus() == ApiStatus.ERROR) {
+                latch.countDown();
+            }
+            return saved;
+        });
+
+        // when
+        contentService.generateContentAsync(requestId, apiLogId);
+
+        awaitLatch(latch);
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(apiLog.getErrorMessage()).isEqualTo(ErrorCode.AI_PARSE_ERROR.getMessage());
+        then(contentRepository).should(never()).save(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("콘텐츠 생성 비동기 예외 치환")
+    void shouldStoreSanitizedMessageWhenGenerateContentAsyncFailsUnexpectedly() throws Exception {
+        // 비동기 생성 중 예상치 못한 예외가 나면 안전한 AI003 메시지로 치환해 저장해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Store store = createStore(user);
+        InputImage input = createInputImage(request, UUID.randomUUID(), "stored/input-1.png", "front", 1);
+        ApiLog apiLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        given(requestRepository.findById(requestId)).willReturn(Optional.of(request));
+        given(inputImageRepository.findByGenerationRequestOrderByDisplayOrderAsc(request)).willReturn(List.of(input));
+        given(storeRepository.findByUser(user)).willReturn(Optional.of(store));
+        given(gcsService.generateSignedUrl("stored/input-1.png")).willReturn("https://signed.example.com/input-1");
+        given(geminiService.generateProcessedContent(any(GeminiPromptRequest.class)))
+                .willReturn(Mono.error(new RuntimeException("secret key leaked")));
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+        given(apiLogRepository.save(any(ApiLog.class))).willAnswer(invocation -> {
+            ApiLog saved = invocation.getArgument(0);
+            if (saved.getStatus() == ApiStatus.ERROR) {
+                latch.countDown();
+            }
+            return saved;
+        });
+
+        // when
+        contentService.generateContentAsync(requestId, apiLogId);
+
+        awaitLatch(latch);
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(apiLog.getErrorMessage()).isEqualTo(ErrorCode.AI_REQUEST_FAILED.getMessage());
+        assertThat(apiLog.getErrorMessage()).doesNotContain("secret");
+        then(contentRepository).should(never()).save(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("작업 상태 조회 성공")
+    void shouldReturnTaskStatus() {
+        // 작업 상태 조회 시 content가 있으면 result에 content id를 포함해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        GenerationRequest request = createGenerationRequest(user, UUID.randomUUID());
+        Content content = createContent(request, UUID.randomUUID(), GenerationType.ALL);
+        ApiLog apiLog = createApiLog(request, UUID.randomUUID(), "gemini-2.5-flash", ApiStatus.SUCCESS);
+        ReflectionTestUtils.setField(apiLog, "content", content);
+
+        given(apiLogRepository.findById(apiLog.getId())).willReturn(Optional.of(apiLog));
+
+        // when
+        TaskStatusResponse response = contentService.getTaskStatus(user, apiLog.getId());
+
+        // then
+        assertThat(response.getTaskId()).isEqualTo(apiLog.getId());
+        assertThat(response.getStatus()).isEqualTo("success");
+        assertThat(response.getResult()).isEqualTo(content.getId().toString());
+        assertThat(response.getErrorMessage()).isNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 작업 상태 조회 실패")
+    void shouldThrowWhenTaskStatusIsMissing() {
+        // 작업 ID가 존재하지 않으면 G002 예외를 반환해야 한다.
+
+        // given
+        given(apiLogRepository.findById(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        TaskNotFoundException exception = assertThrows(
+                TaskNotFoundException.class,
+                () -> contentService.getTaskStatus(createUser("owner@example.com"), UUID.randomUUID())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.TASK_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("타 사용자 작업 상태 조회 거부")
+    void shouldThrowWhenGettingAnotherUsersTaskStatus() {
+        // 다른 사용자의 작업 상태를 조회하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        GenerationRequest request = createGenerationRequest(owner, UUID.randomUUID());
+        ApiLog apiLog = createApiLog(request, UUID.randomUUID(), "gemini-2.5-flash", ApiStatus.PROCESSING);
+        given(apiLogRepository.findById(apiLog.getId())).willReturn(Optional.of(apiLog));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> contentService.getTaskStatus(viewer, apiLog.getId())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 상세 조회 성공")
+    void shouldReturnContentDetail() {
+        // 콘텐츠 상세 조회 시 signed URL과 게시 여부를 함께 반환해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        GenerationRequest request = createGenerationRequest(user, UUID.randomUUID());
+        Content content = createContent(request, UUID.randomUUID(), GenerationType.ALL);
+        ContentImage firstImage = createContentImage(content, UUID.randomUUID(), UUID.randomUUID(), "stored/content-1.png");
+        ContentImage secondImage = createContentImage(content, UUID.randomUUID(), UUID.randomUUID(), "stored/content-2.png");
+
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+        given(contentImageRepository.findByContentOrderByCreatedAtAsc(content)).willReturn(List.of(firstImage, secondImage));
+        given(contentPostRepository.existsByContentAndStatus(content, PublishStatus.COMPLETED)).willReturn(true);
+        given(gcsService.generateSignedUrl("stored/content-1.png")).willReturn("https://signed.example.com/content-1");
+        given(gcsService.generateSignedUrl("stored/content-2.png")).willReturn("https://signed.example.com/content-2");
+
+        // when
+        ContentResponse response = contentService.getContent(user, content.getId());
+
+        // then
+        assertThat(response.getId()).isEqualTo(content.getId());
+        assertThat(response.getRequestId()).isEqualTo(request.getId());
+        assertThat(response.getGenerationType()).isEqualTo(GenerationType.ALL);
+        assertThat(response.getIsPosted()).isTrue();
+        assertThat(response.getContentData().getInstagram().getText()).isEqualTo("Instagram body");
+        assertThat(response.getContentData().getKarrot().getText()).isEqualTo("Karrot body");
+        assertThat(response.getContentData().getNaver().getText()).isEqualTo("Naver body");
+        assertThat(response.getImages()).hasSize(2);
+        assertThat(response.getImages().get(0).getUrl()).isEqualTo("https://signed.example.com/content-1");
+        assertThat(response.getImages().get(1).getUrl()).isEqualTo("https://signed.example.com/content-2");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠 상세 조회 실패")
+    void shouldThrowWhenContentIsMissing() {
+        // 콘텐츠가 존재하지 않으면 C007 예외를 반환해야 한다.
+
+        // given
+        given(contentRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        ContentNotFoundException exception = assertThrows(
+                ContentNotFoundException.class,
+                () -> contentService.getContent(createUser("owner@example.com"), UUID.randomUUID())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CONTENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("타 사용자 콘텐츠 상세 조회 거부")
+    void shouldThrowWhenGettingAnotherUsersContent() {
+        // 다른 사용자의 콘텐츠를 조회하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        Content content = createContent(createGenerationRequest(owner, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> contentService.getContent(viewer, content.getId())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 목록 조회 성공")
+    void shouldReturnContentList() {
+        // 콘텐츠 목록 조회 시 게시 여부와 잘린 preview를 함께 반환해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Content firstContent = createContent(request, UUID.randomUUID(), GenerationType.ALL);
+        Content secondContent = createContent(request, UUID.randomUUID(), GenerationType.TEXT_ONLY);
+        ReflectionTestUtils.setField(firstContent, "instagramText", "123456789012345678901234567890XYZ");
+        ReflectionTestUtils.setField(firstContent, "karrotText", "Short karrot");
+        ReflectionTestUtils.setField(firstContent, "naverText", "");
+        ReflectionTestUtils.setField(secondContent, "instagramText", null);
+        ReflectionTestUtils.setField(secondContent, "karrotText", "Another short line");
+        ReflectionTestUtils.setField(secondContent, "naverText", "Second naver preview");
+
+        given(requestRepository.findByIdAndIsDeletedFalse(requestId)).willReturn(Optional.of(request));
+        given(contentRepository.findByGenerationRequestAndIsDeletedFalseOrderByCreatedAtDesc(request))
+                .willReturn(List.of(firstContent, secondContent));
+        given(contentPostRepository.findContentIdsByContentInAndStatus(List.of(firstContent, secondContent), PublishStatus.COMPLETED))
+                .willReturn(List.of(firstContent.getId()));
+
+        // when
+        ContentListResponse response = contentService.getContentList(user, requestId);
+
+        // then
+        assertThat(response.getRequestId()).isEqualTo(requestId);
+        assertThat(response.getContents()).hasSize(2);
+        assertThat(response.getContents().get(0).getContentId()).isEqualTo(firstContent.getId());
+        assertThat(response.getContents().get(0).getIsPosted()).isTrue();
+        assertThat(response.getContents().get(0).getInstagramPreview()).isEqualTo("123456789012345678901234567890...");
+        assertThat(response.getContents().get(0).getKarrotPreview()).isEqualTo("Short karrot");
+        assertThat(response.getContents().get(1).getIsPosted()).isFalse();
+        assertThat(response.getContents().get(1).getInstagramPreview()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 요청 콘텐츠 목록 조회 실패")
+    void shouldThrowWhenContentListRequestIsMissing() {
+        // 생성 요청이 존재하지 않으면 콘텐츠 목록 조회에 실패해야 한다.
+
+        // given
+        given(requestRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        GenerationRequestNotFoundException exception = assertThrows(
+                GenerationRequestNotFoundException.class,
+                () -> contentService.getContentList(createUser("owner@example.com"), UUID.randomUUID())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GENERATION_REQUEST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("타 사용자 콘텐츠 목록 조회 거부")
+    void shouldThrowWhenGettingAnotherUsersContentList() {
+        // 다른 사용자의 생성 요청으로 목록 조회를 시도하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        GenerationRequest request = createGenerationRequest(owner, UUID.randomUUID());
+        given(requestRepository.findByIdAndIsDeletedFalse(request.getId())).willReturn(Optional.of(request));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> contentService.getContentList(viewer, request.getId())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 수정 성공")
+    void shouldUpdateContentPartially() {
+        // 콘텐츠 수정 시 요청에 포함된 플랫폼만 바꾸고 나머지는 유지해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        Content content = createContent(createGenerationRequest(user, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+        ContentImage image = createContentImage(content, UUID.randomUUID(), UUID.randomUUID(), "stored/content-1.png");
+        UpdateContentRequest request = UpdateContentRequest.builder()
+                .instagram(UpdateContentRequest.PlatformUpdate.builder()
+                        .text("Updated instagram")
+                        .hashtags(List.of("#new"))
+                        .build())
+                .naver(UpdateContentRequest.PlatformUpdate.builder()
+                        .text("Updated naver")
+                        .hashtags(null)
+                        .build())
+                .build();
+
+        given(userRepository.findByEmail("owner@example.com")).willReturn(Optional.of(user));
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+        given(contentRepository.saveAndFlush(content)).willReturn(content);
+        given(contentImageRepository.findByContentOrderByCreatedAtAsc(content)).willReturn(List.of(image));
+        given(contentPostRepository.existsByContentAndStatus(content, PublishStatus.COMPLETED)).willReturn(false);
+        given(gcsService.generateSignedUrl("stored/content-1.png")).willReturn("https://signed.example.com/content-1");
+
+        // when
+        ContentResponse response = contentService.updateContent("owner@example.com", content.getId(), request);
+
+        // then
+        assertThat(content.getInstagramText()).isEqualTo("Updated instagram");
+        assertThat(content.getInstagramHashtags()).containsExactly("#new");
+        assertThat(content.getKarrotText()).isEqualTo("Karrot body");
+        assertThat(content.getKarrotTags()).containsExactly("#karrot");
+        assertThat(content.getNaverText()).isEqualTo("Updated naver");
+        assertThat(content.getNaverKeywords()).containsExactly("#naver");
+        assertThat(response.getImages().get(0).getUrl()).isEqualTo("https://signed.example.com/content-1");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 콘텐츠 수정 실패")
+    void shouldThrowWhenUpdatingContentForMissingUser() {
+        // 사용자 이메일이 존재하지 않으면 콘텐츠 수정에 실패해야 한다.
+
+        // given
+        given(userRepository.findByEmail("missing@example.com")).willReturn(Optional.empty());
+
+        // when
+        UserNotFoundException exception = assertThrows(
+                UserNotFoundException.class,
+                () -> contentService.updateContent("missing@example.com", UUID.randomUUID(), UpdateContentRequest.builder().build())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠 수정 실패")
+    void shouldThrowWhenUpdatingMissingContent() {
+        // 콘텐츠가 존재하지 않으면 수정에 실패해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        given(userRepository.findByEmail("owner@example.com")).willReturn(Optional.of(user));
+        given(contentRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        ContentNotFoundException exception = assertThrows(
+                ContentNotFoundException.class,
+                () -> contentService.updateContent("owner@example.com", UUID.randomUUID(), UpdateContentRequest.builder().build())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CONTENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("타 사용자 콘텐츠 수정 거부")
+    void shouldThrowWhenUpdatingAnotherUsersContent() {
+        // 다른 사용자의 콘텐츠를 수정하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        Content content = createContent(createGenerationRequest(owner, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+        given(userRepository.findByEmail("viewer@example.com")).willReturn(Optional.of(viewer));
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> contentService.updateContent("viewer@example.com", content.getId(), UpdateContentRequest.builder().build())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 삭제 성공")
+    void shouldDeleteContent() {
+        // 콘텐츠 삭제 시 soft delete 처리 후 저장해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        Content content = createContent(createGenerationRequest(user, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+        given(contentRepository.save(content)).willReturn(content);
+
+        // when
+        contentService.deleteContent(user, content.getId());
+
+        // then
+        assertThat(content.getIsDeleted()).isTrue();
+        assertThat(content.getDeletedAt()).isNotNull();
+        then(contentRepository).should().save(content);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠 삭제 실패")
+    void shouldThrowWhenDeletingMissingContent() {
+        // 콘텐츠가 존재하지 않으면 삭제에 실패해야 한다.
+
+        // given
+        given(contentRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        ContentNotFoundException exception = assertThrows(
+                ContentNotFoundException.class,
+                () -> contentService.deleteContent(createUser("owner@example.com"), UUID.randomUUID())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CONTENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("타 사용자 콘텐츠 삭제 거부")
+    void shouldThrowWhenDeletingAnotherUsersContent() {
+        // 다른 사용자의 콘텐츠를 삭제하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        Content content = createContent(createGenerationRequest(owner, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> contentService.deleteContent(viewer, content.getId())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 재생성 시작 성공")
+    void shouldStartRegeneration() {
+        // 유효한 재생성 요청이면 processing ApiLog를 저장하고 비동기 재생성을 시작해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID contentId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Content originalContent = createContent(request, contentId, GenerationType.ALL);
+        ApiLog savedLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+
+        given(contentRepository.findByIdAndIsDeletedFalse(contentId)).willReturn(Optional.of(originalContent));
+        given(geminiConfig.getModel()).willReturn("gemini-2.5-flash");
+        given(apiLogRepository.save(any(ApiLog.class))).willReturn(savedLog);
+
+        // when
+        GenerateContentResponse response = testableContentService.startRegeneration(
+                user,
+                contentId,
+                RegenerateContentRequest.builder()
+                        .feedback("Make it more friendly")
+                        .regenerateImage(true)
+                        .target("INSTAGRAM")
+                        .build()
+        );
+
+        // then
+        assertThat(response.getRequestId()).isEqualTo(requestId);
+        assertThat(response.getTaskId()).isEqualTo(apiLogId);
+        assertThat(response.getStartedAt()).isNotNull();
+        assertThat(testableContentService.regenerateAsyncCalled).isTrue();
+        assertThat(testableContentService.capturedRequestId).isEqualTo(requestId);
+        assertThat(testableContentService.capturedOriginalContentId).isEqualTo(contentId);
+        assertThat(testableContentService.capturedApiLogId).isEqualTo(apiLogId);
     }
 
     @Test
@@ -128,13 +846,127 @@ class ContentServiceTest {
         // when
         InvalidRegenerationRequestException exception = assertThrows(
                 InvalidRegenerationRequestException.class,
-                () -> contentService.startRegeneration(user, contentId, request)
+                () -> testableContentService.startRegeneration(user, contentId, request)
         );
 
         // then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REGENERATION_REQUEST);
-        assertThat(contentService.regenerateAsyncCalled).isFalse();
+        assertThat(testableContentService.regenerateAsyncCalled).isFalse();
         then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠 재생성 시작 실패")
+    void shouldThrowWhenStartingRegenerationForMissingContent() {
+        // 원본 콘텐츠가 없으면 재생성 시작에 실패해야 한다.
+
+        // given
+        given(contentRepository.findByIdAndIsDeletedFalse(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        ContentNotFoundException exception = assertThrows(
+                ContentNotFoundException.class,
+                () -> testableContentService.startRegeneration(
+                        createUser("owner@example.com"),
+                        UUID.randomUUID(),
+                        RegenerateContentRequest.builder().feedback("Change it").target("INSTAGRAM").build())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CONTENT_NOT_FOUND);
+        then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("타 사용자 콘텐츠 재생성 시작 거부")
+    void shouldThrowWhenStartingRegenerationForAnotherUsersContent() {
+        // 다른 사용자의 콘텐츠로 재생성을 시작하면 접근 거부 예외를 반환해야 한다.
+
+        // given
+        User owner = createUser("owner@example.com");
+        User viewer = createUser("viewer@example.com");
+        Content originalContent = createContent(createGenerationRequest(owner, UUID.randomUUID()), UUID.randomUUID(), GenerationType.ALL);
+        given(contentRepository.findByIdAndIsDeletedFalse(originalContent.getId())).willReturn(Optional.of(originalContent));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> testableContentService.startRegeneration(
+                        viewer,
+                        originalContent.getId(),
+                        RegenerateContentRequest.builder().feedback("Change it").target("INSTAGRAM").build())
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_TO_RESOURCE);
+        then(apiLogRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("인스타그램 재생성 비동기 성공")
+    void shouldRegenerateInstagramOnly() throws Exception {
+        // INSTAGRAM 재생성은 인스타그램 필드만 교체하고 나머지 플랫폼은 유지해야 한다.
+
+        assertRegenerationSuccess("INSTAGRAM", "New instagram", List.of("#renewed"));
+    }
+
+    @Test
+    @DisplayName("당근 재생성 비동기 성공")
+    void shouldRegenerateKarrotOnly() throws Exception {
+        // KARROT 재생성은 당근 필드만 교체하고 나머지 플랫폼은 유지해야 한다.
+
+        assertRegenerationSuccess("KARROT", "New karrot", List.of("#market"));
+    }
+
+    @Test
+    @DisplayName("네이버 재생성 비동기 성공")
+    void shouldRegenerateNaverOnly() throws Exception {
+        // NAVER 재생성은 네이버 필드만 교체하고 나머지 플랫폼은 유지해야 한다.
+
+        assertRegenerationSuccess("NAVER", "New naver", List.of("#search"));
+    }
+
+    @Test
+    @DisplayName("재생성 비동기 예외 치환")
+    void shouldStoreSanitizedMessageWhenRegenerationFails() throws Exception {
+        // 재생성 비동기 중 예상치 못한 예외가 나면 안전한 AI003 메시지로 치환해 저장해야 한다.
+
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID contentId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Content originalContent = createContent(request, contentId, GenerationType.ALL);
+        ApiLog apiLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        given(contentRepository.findById(contentId)).willReturn(Optional.of(originalContent));
+        given(geminiService.generateProcessedRegenerationContent(any(GeminiRegenerationRequest.class)))
+                .willReturn(Mono.error(new RuntimeException("https://example.test?key=secret")));
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+        given(apiLogRepository.save(any(ApiLog.class))).willAnswer(invocation -> {
+            ApiLog saved = invocation.getArgument(0);
+            if (saved.getStatus() == ApiStatus.ERROR) {
+                latch.countDown();
+            }
+            return saved;
+        });
+
+        // when
+        contentService.regenerateContentAsync(
+                requestId,
+                contentId,
+                RegenerateContentRequest.builder().feedback("Change it").regenerateImage(true).target("INSTAGRAM").build(),
+                apiLogId
+        );
+
+        awaitLatch(latch);
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(apiLog.getErrorMessage()).isEqualTo(ErrorCode.AI_REQUEST_FAILED.getMessage());
+        then(contentImageRepository).should(never()).save(any(ContentImage.class));
     }
 
     @Test
@@ -164,14 +996,202 @@ class ContentServiceTest {
         assertThat(safeMessage).isEqualTo(ErrorCode.AI_PARSE_ERROR.getMessage());
     }
 
+    private void assertRegenerationSuccess(String target, String regeneratedText, List<String> regeneratedHashtags) throws Exception {
+        // given
+        User user = createUser("owner@example.com");
+        UUID requestId = UUID.randomUUID();
+        UUID originalContentId = UUID.randomUUID();
+        UUID regeneratedContentId = UUID.randomUUID();
+        UUID apiLogId = UUID.randomUUID();
+        GenerationRequest request = createGenerationRequest(user, requestId);
+        Content originalContent = createContent(request, originalContentId, GenerationType.ALL);
+        ContentImage image = createContentImage(originalContent, UUID.randomUUID(), UUID.randomUUID(), "stored/content-1.png");
+        ApiLog apiLog = createApiLog(request, apiLogId, "gemini-2.5-flash", ApiStatus.PROCESSING);
+        GeminiParsedResponse parsed = GeminiParsedResponse.builder()
+                .text(regeneratedText)
+                .hashtags(regeneratedHashtags)
+                .inputTokens(2_000)
+                .outputTokens(1_000)
+                .responseTimeMs(654L)
+                .build();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        given(contentRepository.findById(originalContentId)).willReturn(Optional.of(originalContent));
+        given(requestRepository.findById(requestId)).willReturn(Optional.of(request));
+        given(geminiService.generateProcessedRegenerationContent(any(GeminiRegenerationRequest.class))).willReturn(Mono.just(parsed));
+        given(contentRepository.save(any(Content.class))).willAnswer(invocation -> {
+            Content saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", regeneratedContentId);
+            return saved;
+        });
+        given(contentImageRepository.findByContentOrderByCreatedAtAsc(originalContent)).willReturn(List.of(image));
+        given(contentImageRepository.save(any(ContentImage.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+        given(apiLogRepository.save(any(ApiLog.class))).willAnswer(invocation -> {
+            ApiLog saved = invocation.getArgument(0);
+            if (saved.getStatus() == ApiStatus.SUCCESS) {
+                latch.countDown();
+            }
+            return saved;
+        });
+
+        // when
+        contentService.regenerateContentAsync(
+                requestId,
+                originalContentId,
+                RegenerateContentRequest.builder()
+                        .feedback("Make it more playful")
+                        .regenerateImage(true)
+                        .target(target)
+                        .build(),
+                apiLogId
+        );
+
+        awaitLatch(latch);
+
+        // then
+        ArgumentCaptor<GeminiRegenerationRequest> requestCaptor = ArgumentCaptor.forClass(GeminiRegenerationRequest.class);
+        then(geminiService).should().generateProcessedRegenerationContent(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().getTarget()).isEqualTo(target);
+        if ("INSTAGRAM".equals(target)) {
+            assertThat(requestCaptor.getValue().getOriginalText()).isEqualTo("Instagram body");
+            assertThat(requestCaptor.getValue().getOriginalHashtags()).containsExactly("#insta");
+        } else if ("KARROT".equals(target)) {
+            assertThat(requestCaptor.getValue().getOriginalText()).isEqualTo("Karrot body");
+            assertThat(requestCaptor.getValue().getOriginalHashtags()).containsExactly("#karrot");
+        } else {
+            assertThat(requestCaptor.getValue().getOriginalText()).isEqualTo("Naver body");
+            assertThat(requestCaptor.getValue().getOriginalHashtags()).containsExactly("#naver");
+        }
+
+        ArgumentCaptor<Content> contentCaptor = ArgumentCaptor.forClass(Content.class);
+        then(contentRepository).should().save(contentCaptor.capture());
+        Content savedContent = contentCaptor.getValue();
+        assertThat(savedContent.getGenerationType()).isEqualTo(GenerationType.TEXT_ONLY);
+        if ("INSTAGRAM".equals(target)) {
+            assertThat(savedContent.getInstagramText()).isEqualTo(regeneratedText);
+            assertThat(savedContent.getInstagramHashtags()).containsExactlyElementsOf(regeneratedHashtags);
+            assertThat(savedContent.getKarrotText()).isEqualTo("Karrot body");
+            assertThat(savedContent.getNaverText()).isEqualTo("Naver body");
+        } else if ("KARROT".equals(target)) {
+            assertThat(savedContent.getKarrotText()).isEqualTo(regeneratedText);
+            assertThat(savedContent.getKarrotTags()).containsExactlyElementsOf(regeneratedHashtags);
+            assertThat(savedContent.getInstagramText()).isEqualTo("Instagram body");
+            assertThat(savedContent.getNaverText()).isEqualTo("Naver body");
+        } else {
+            assertThat(savedContent.getNaverText()).isEqualTo(regeneratedText);
+            assertThat(savedContent.getNaverKeywords()).containsExactlyElementsOf(regeneratedHashtags);
+            assertThat(savedContent.getInstagramText()).isEqualTo("Instagram body");
+            assertThat(savedContent.getKarrotText()).isEqualTo("Karrot body");
+        }
+
+        ArgumentCaptor<ContentImage> imageCaptor = ArgumentCaptor.forClass(ContentImage.class);
+        then(contentImageRepository).should().save(imageCaptor.capture());
+        assertThat(imageCaptor.getValue().getInputImageId()).isEqualTo(image.getInputImageId());
+        assertThat(imageCaptor.getValue().getUrl()).isEqualTo(image.getUrl());
+        then(gcsService).should(never()).copyFile(any(), any());
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        assertThat(apiLog.getContent()).isNotNull();
+        assertThat(apiLog.getContent().getId()).isEqualTo(regeneratedContentId);
+        assertThat(apiLog.getCostUsd()).isEqualByComparingTo("0.0040000000");
+    }
+
+    private void awaitLatch(CountDownLatch latch) throws InterruptedException {
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
     private User createUser(String email) {
         User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
         ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
         return user;
     }
 
+    private GenerationRequest createGenerationRequest(User user, UUID requestId) {
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept("Spring promotion")
+                .additionalNote("Bright mood")
+                .targetAge("20s")
+                .targetGender("ALL")
+                .build();
+        ReflectionTestUtils.setField(request, "id", requestId);
+        ReflectionTestUtils.setField(request, "createdAt", LocalDateTime.of(2026, 4, 14, 10, 0));
+        ReflectionTestUtils.setField(request, "updatedAt", LocalDateTime.of(2026, 4, 14, 10, 5));
+        return request;
+    }
+
+    private Store createStore(User user) {
+        Store store = Store.builder()
+                .user(user)
+                .storeName("Today Cafe")
+                .businessType("Cafe")
+                .address("Seoul")
+                .latitude(new BigDecimal("37.50000000"))
+                .longitude(new BigDecimal("127.00000000"))
+                .preferredStyle(PreferredStyle.CLEAN)
+                .snsInstagram("@todaycafe")
+                .build();
+        ReflectionTestUtils.setField(store, "id", UUID.randomUUID());
+        return store;
+    }
+
+    private InputImage createInputImage(GenerationRequest request, UUID imageId, String url, String description, int displayOrder) {
+        InputImage image = InputImage.builder()
+                .generationRequest(request)
+                .url(url)
+                .description(description)
+                .displayOrder(displayOrder)
+                .build();
+        ReflectionTestUtils.setField(image, "id", imageId);
+        ReflectionTestUtils.setField(image, "createdAt", LocalDateTime.of(2026, 4, 14, 10, 10 + displayOrder));
+        return image;
+    }
+
+    private Content createContent(GenerationRequest request, UUID contentId, GenerationType generationType) {
+        Content content = Content.builder()
+                .generationRequest(request)
+                .instagramText("Instagram body")
+                .instagramHashtags(List.of("#insta"))
+                .karrotText("Karrot body")
+                .karrotTags(List.of("#karrot"))
+                .naverText("Naver body")
+                .naverKeywords(List.of("#naver"))
+                .generationType(generationType)
+                .aiModel("gemini-2.5-flash")
+                .build();
+        ReflectionTestUtils.setField(content, "id", contentId);
+        ReflectionTestUtils.setField(content, "createdAt", LocalDateTime.of(2026, 4, 14, 11, 0));
+        ReflectionTestUtils.setField(content, "updatedAt", LocalDateTime.of(2026, 4, 14, 11, 5));
+        return content;
+    }
+
+    private ContentImage createContentImage(Content content, UUID imageId, UUID inputImageId, String url) {
+        ContentImage image = ContentImage.builder()
+                .content(content)
+                .inputImageId(inputImageId)
+                .url(url)
+                .build();
+        ReflectionTestUtils.setField(image, "id", imageId);
+        ReflectionTestUtils.setField(image, "createdAt", LocalDateTime.of(2026, 4, 14, 11, 10));
+        return image;
+    }
+
+    private ApiLog createApiLog(GenerationRequest request, UUID apiLogId, String model, ApiStatus status) {
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model(model)
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(apiLog, "id", apiLogId);
+        return apiLog;
+    }
+
     private static class TestableContentService extends ContentService {
+        private boolean generateAsyncCalled;
         private boolean regenerateAsyncCalled;
+        private UUID capturedRequestId;
+        private UUID capturedOriginalContentId;
+        private UUID capturedApiLogId;
 
         TestableContentService(
                 ContentRepository contentRepository,
@@ -204,8 +1224,18 @@ class ContentServiceTest {
         }
 
         @Override
+        public void generateContentAsync(UUID requestId, UUID apiLogId) {
+            generateAsyncCalled = true;
+            capturedRequestId = requestId;
+            capturedApiLogId = apiLogId;
+        }
+
+        @Override
         public void regenerateContentAsync(UUID requestId, UUID originalContentId, RegenerateContentRequest regenerateRequest, UUID apiLogId) {
             regenerateAsyncCalled = true;
+            capturedRequestId = requestId;
+            capturedOriginalContentId = originalContentId;
+            capturedApiLogId = apiLogId;
         }
     }
 }


### PR DESCRIPTION
## Issue Number
closed #54 

## As-Is
- Gemini API 연동 및 콘텐츠 관리 API 관련 회귀 테스트 부족

## To-Be
- GeminiService 요청 헤더 전송, 응답 파싱, 해시태그 정규화, 재생성 후처리, 예외 처리 테스트 추가
- GcsService 성공, 실패, 예외 케이스 테스트 추가
- ContentController 생성, 상태 조회, 목록, 상세, 수정, 삭제, 재생성 및 rate limit/validation WebMvc 테스트 추가
- ContentService 생성/재생성 시작, 비동기 성공/예외 치환, 권한/조회/수정/삭제 테스트 추가
- GlobalExceptionHandler의 신규 에러 코드 응답 매핑 테스트 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
