### PR TITLE
[Fix] OAuth 로그인 Exception 로깅 추가

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/service/AuthenticationService.java
@@ -210,7 +210,10 @@ public class AuthenticationService {
                     .onStatus(org.springframework.http.HttpStatusCode::isError, clientResponse -> {
                         log.error("Error while getting user attributes: {}", clientResponse.statusCode());
                         return clientResponse.bodyToMono(String.class)
-                                .map(body -> new InvalidOauthAccessTokenException());
+                                .map(body -> {
+                                    log.error("Kakao API error response: {}", body);
+                                    return new InvalidOauthAccessTokenException();
+                                });
                     })
                     .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                     .block();


### PR DESCRIPTION
## Issue Number
closed #56 

## As-Is
- oauth 로그인 실패시 원인 파악에 어려움

## To-Be
- Authentication.getUserAttribute : exception 발생시 상세 로그(error response body) 추가.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
