### PR TITLE
[Test] 컨텐츠 업로드 및 OAuth 테스트 코드 작성

### DIFF
--- a/backend-spring/today-store/src/test/java/today_store/authentication/service/AuthenticationServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/authentication/service/AuthenticationServiceTest.java
@@ -162,6 +162,52 @@ class AuthenticationServiceTest {
     }
 
     @Test
+    @DisplayName("OAuth 이메일 누락 시 대체 이메일 생성")
+    void shouldCreateFallbackEmailWhenOauthProviderDoesNotReturnEmail() {
+        // Kakao처럼 이메일을 내려주지 않는 OAuth 제공자라도 로그인은 실패하지 않고
+        // providerId/provider 조합의 대체 이메일로 사용자를 저장해야 한다.
+
+        // given
+        authenticationService = createService(createWebClient(
+                jsonResponse(HttpStatus.OK, """
+                        {"id":12345,"properties":{"nickname":"Kakao User","profile_image":"https://image.test/kakao.png"},"kakao_account":{}}
+                        """)
+        ));
+        ClientRegistration clientRegistration = createKakaoClientRegistration();
+        UUID savedUserId = UUID.randomUUID();
+        LoginRequest loginRequest = new LoginRequest("kakao", "valid-kakao-token");
+
+        given(clientRegistrationRepository.findByRegistrationId("kakao")).willReturn(clientRegistration);
+        given(userRepository.findByProviderAndProviderId("kakao", "12345")).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", savedUserId);
+            return user;
+        });
+        given(jwtTokenProvider.createAccessToken(any(Authentication.class))).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(any(Authentication.class))).willReturn("refresh-token");
+
+        // when
+        LoginResponse response = authenticationService.oauthLogin(loginRequest);
+
+        // then
+        assertThat(response.getUser().getId()).isEqualTo(savedUserId);
+        assertThat(response.getUser().getEmail()).isEqualTo("12345@kakao.com");
+        assertThat(response.getUser().getName()).isEqualTo("Kakao User");
+        assertThat(response.getUser().isFirstLogin()).isTrue();
+        then(userRepository).should().save(argThat(user ->
+                user.getEmail().equals("12345@kakao.com")
+                        && user.getProvider().equals("kakao")
+                        && user.getProviderId().equals("12345")
+                        && user.getProfileImageUrl().equals("https://image.test/kakao.png")
+        ));
+        then(refreshTokenRepository).should().save(argThat(token ->
+                token.getUserId().equals(savedUserId)
+                        && token.getRefreshToken().equals("refresh-token")
+        ));
+    }
+
+    @Test
     @DisplayName("지원하지 않는 소셜 제공자 거부")
     void shouldThrowUnsupportedProviderExceptionWhenProviderIsUnsupported() {
         // 등록되지 않은 OAuth 제공자로 로그인하면 지원하지 않는 제공자 예외를 반환해야 한다.
@@ -494,6 +540,21 @@ class AuthenticationServiceTest {
                 .userInfoUri("https://example.test/user/me")
                 .userNameAttributeName("sub")
                 .clientName("Google")
+                .build();
+    }
+
+    private ClientRegistration createKakaoClientRegistration() {
+        return ClientRegistration.withRegistrationId("kakao")
+                .clientId("kakao-client-id")
+                .clientSecret("kakao-client-secret")
+                .redirectUri("http://localhost/test/oauth/kakao")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .scope("profile_nickname", "account_email")
+                .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+                .tokenUri("https://kauth.kakao.com/oauth/token")
+                .userInfoUri("https://kapi.kakao.com/v2/user/me")
+                .userNameAttributeName("id")
+                .clientName("Kakao")
                 .build();
     }
 

--- a/backend-spring/today-store/src/test/java/today_store/common/instagram/service/InstagramServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/instagram/service/InstagramServiceTest.java
@@ -1,0 +1,374 @@
+package today_store.common.instagram.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import today_store.authentication.entity.User;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.common.gcs.GcsService;
+import today_store.common.instagram.client.InstagramClient;
+import today_store.common.instagram.dto.InstagramAuthRequest;
+import today_store.common.instagram.dto.InstagramAuthResponse;
+import today_store.common.instagram.dto.InstagramPublishRequest;
+import today_store.common.instagram.dto.InstagramPublishResponse;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentImage;
+import today_store.content.content.entity.ContentPlatform;
+import today_store.content.content.entity.ContentPost;
+import today_store.content.content.repository.ContentImageRepository;
+import today_store.content.content.repository.ContentRepository;
+import today_store.content.publish.service.PublishPostService;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.user.entity.UserSocialAccount;
+import today_store.user.repository.UserSocialAccountRepository;
+import today_store.user.service.UserSocialAccountService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("인스타그램 서비스 테스트")
+class InstagramServiceTest {
+
+    @Mock
+    private InstagramClient instagramClient;
+
+    @Mock
+    private UserSocialAccountRepository userSocialAccountRepository;
+
+    @Mock
+    private UserSocialAccountService userSocialAccountService;
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    @Mock
+    private ContentImageRepository contentImageRepository;
+
+    @Mock
+    private PublishPostService publishPostService;
+
+    @Mock
+    private GcsService gcsService;
+
+    private InstagramService instagramService;
+
+    @BeforeEach
+    void setUp() {
+        instagramService = new InstagramService(
+                instagramClient,
+                userSocialAccountRepository,
+                userSocialAccountService,
+                contentRepository,
+                contentImageRepository,
+                publishPostService,
+                gcsService
+        );
+    }
+
+    @Test
+    @DisplayName("인스타그램 인증 시 장기 토큰 계정 연결")
+    void shouldAuthenticateAndLinkInstagramAccount() {
+        // 인스타그램 OAuth는 단기 인증 코드를 장기 토큰으로 교환한 뒤
+        // 조회된 인스타그램 식별자와 함께 장기 토큰만 계정에 연결해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        InstagramAuthRequest request = new InstagramAuthRequest();
+        request.setAuthCode("auth-code");
+        request.setRedirectUri("https://app.test/oauth/instagram/callback");
+        LocalDateTime beforeCall = LocalDateTime.now();
+
+        given(instagramClient.getShortLivedToken("auth-code", "https://app.test/oauth/instagram/callback"))
+                .willReturn("short-lived-token");
+        given(instagramClient.getLongLivedToken("short-lived-token"))
+                .willReturn(Map.of("access_token", "long-lived-token", "expires_in", 3600));
+        given(instagramClient.getUserInfo("long-lived-token"))
+                .willReturn(Map.of("id", "ig-user-id", "username", "today_store"));
+
+        // when
+        InstagramAuthResponse response = instagramService.authenticate(user, request);
+
+        // then
+        assertThat(response.getInstagramUserId()).isEqualTo("ig-user-id");
+        assertThat(response.getUsername()).isEqualTo("today_store");
+        then(userSocialAccountService).should().linkAccount(
+                eq(user),
+                eq("INSTAGRAM"),
+                eq("ig-user-id"),
+                eq("today_store"),
+                eq("long-lived-token"),
+                argThat(expiresAt ->
+                        !expiresAt.isBefore(beforeCall.plusSeconds(3599))
+                                && !expiresAt.isAfter(LocalDateTime.now().plusSeconds(3601))
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("단일 이미지 게시 성공 시 게시 완료 처리")
+    void shouldPublishSingleImageAndCompletePost() {
+        // 인스타그램 게시 성공 시 signed 이미지 URL과 해시태그가 포함된 캡션으로
+        // 미디어를 게시하고, 인스타그램 메타데이터로 진행 중 게시를 완료해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        ContentImage image = createImage(content, "contents/instagram.png");
+        UserSocialAccount account = createInstagramAccount(user, true, LocalDateTime.now().plusDays(1));
+        ContentPost inProgressPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .build();
+        InstagramPublishRequest request = createPublishRequest(content.getId());
+        LocalDateTime expectedPublishedAt = LocalDateTime.of(2026, 4, 20, 10, 15, 30);
+
+        given(contentRepository.findById(content.getId())).willReturn(Optional.of(content));
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM")).willReturn(Optional.of(account));
+        given(contentImageRepository.findByContentId(content.getId())).willReturn(List.of(image));
+        given(publishPostService.createInProgressPost(content, ContentPlatform.INSTAGRAM)).willReturn(inProgressPost);
+        given(gcsService.generateSignedUrl("contents/instagram.png")).willReturn("https://signed.test/instagram.png");
+        given(instagramClient.createMediaContainer(
+                "ig-user-id",
+                "long-lived-token",
+                "https://signed.test/instagram.png",
+                "Instagram caption\n\n#fresh #sale",
+                false
+        )).willReturn("creation-id");
+        given(instagramClient.publishMedia("ig-user-id", "long-lived-token", "creation-id")).willReturn("media-id");
+        given(instagramClient.getMediaInfo("media-id", "long-lived-token"))
+                .willReturn(Map.of(
+                        "permalink", "https://instagram.com/p/media-id",
+                        "timestamp", "2026-04-20T10:15:30+0000"
+                ));
+
+        // when
+        InstagramPublishResponse response = instagramService.publish(user, request);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo("success");
+        assertThat(response.getPostId()).isEqualTo(inProgressPost.getId());
+        assertThat(response.getMediaId()).isEqualTo("media-id");
+        assertThat(response.getLink()).isEqualTo("https://instagram.com/p/media-id");
+        assertThat(response.getPublishedAt()).isEqualTo(expectedPublishedAt);
+        then(publishPostService).should().completePost(
+                inProgressPost.getId(),
+                "media-id",
+                "https://instagram.com/p/media-id",
+                expectedPublishedAt
+        );
+        then(publishPostService).should(never()).failPost(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("다중 이미지 게시 시 캐러셀 사용")
+    void shouldPublishCarouselWhenContentHasMultipleImages() {
+        // 이미지가 여러 장이면 먼저 캐러셀 하위 컨테이너를 생성하고
+        // 최종 캡션을 가진 캐러셀 컨테이너를 통해 게시해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        ContentImage firstImage = createImage(content, "contents/first.png");
+        ContentImage secondImage = createImage(content, "contents/second.png");
+        UserSocialAccount account = createInstagramAccount(user, true, LocalDateTime.now().plusDays(1));
+        ContentPost inProgressPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .build();
+        InstagramPublishRequest request = createPublishRequest(content.getId());
+        LocalDateTime expectedPublishedAt = LocalDateTime.of(2026, 4, 20, 11, 20, 30);
+
+        given(contentRepository.findById(content.getId())).willReturn(Optional.of(content));
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM")).willReturn(Optional.of(account));
+        given(contentImageRepository.findByContentId(content.getId())).willReturn(List.of(firstImage, secondImage));
+        given(publishPostService.createInProgressPost(content, ContentPlatform.INSTAGRAM)).willReturn(inProgressPost);
+        given(gcsService.generateSignedUrl("contents/first.png")).willReturn("https://signed.test/first.png");
+        given(gcsService.generateSignedUrl("contents/second.png")).willReturn("https://signed.test/second.png");
+        given(instagramClient.createMediaContainer(
+                "ig-user-id",
+                "long-lived-token",
+                "https://signed.test/first.png",
+                null,
+                true
+        )).willReturn("child-container-1");
+        given(instagramClient.createMediaContainer(
+                "ig-user-id",
+                "long-lived-token",
+                "https://signed.test/second.png",
+                null,
+                true
+        )).willReturn("child-container-2");
+        given(instagramClient.createCarouselContainer(
+                "ig-user-id",
+                "long-lived-token",
+                List.of("child-container-1", "child-container-2"),
+                "Instagram caption\n\n#fresh #sale"
+        )).willReturn("carousel-container-id");
+        given(instagramClient.publishMedia("ig-user-id", "long-lived-token", "carousel-container-id")).willReturn("media-id");
+        given(instagramClient.getMediaInfo("media-id", "long-lived-token"))
+                .willReturn(Map.of(
+                        "permalink", "https://instagram.com/p/carousel-id",
+                        "timestamp", "2026-04-20T11:20:30+0000"
+                ));
+
+        // when
+        InstagramPublishResponse response = instagramService.publish(user, request);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo("success");
+        assertThat(response.getLink()).isEqualTo("https://instagram.com/p/carousel-id");
+        assertThat(response.getPublishedAt()).isEqualTo(expectedPublishedAt);
+        then(instagramClient).should().createCarouselContainer(
+                "ig-user-id",
+                "long-lived-token",
+                List.of("child-container-1", "child-container-2"),
+                "Instagram caption\n\n#fresh #sale"
+        );
+        then(publishPostService).should().completePost(
+                inProgressPost.getId(),
+                "media-id",
+                "https://instagram.com/p/carousel-id",
+                expectedPublishedAt
+        );
+        then(publishPostService).should(never()).failPost(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("인스타그램 토큰 만료 시 게시 거부")
+    void shouldRejectPublishWhenInstagramTokenIsExpired() {
+        // 토큰 유효성은 게시 초안 생성이나 외부 API 호출보다 먼저 확인되어야 하며
+        // 만료된 인스타그램 인증 정보는 게시 기록을 남기지 않고 즉시 실패해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        UserSocialAccount expiredAccount = createInstagramAccount(user, true, LocalDateTime.now().minusMinutes(1));
+        InstagramPublishRequest request = createPublishRequest(content.getId());
+
+        given(contentRepository.findById(content.getId())).willReturn(Optional.of(content));
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM")).willReturn(Optional.of(expiredAccount));
+
+        // when
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> instagramService.publish(user, request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INSTAGRAM_TOKEN_EXPIRED);
+        then(contentImageRepository).should(never()).findByContentId(any(UUID.class));
+        then(publishPostService).should(never()).createInProgressPost(any(Content.class), any(ContentPlatform.class));
+        then(instagramClient).should(never()).createMediaContainer(any(), any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("인스타그램 API 실패 시 게시 실패 처리")
+    void shouldMarkPostFailedWhenInstagramPublishFailsAfterPostCreation() {
+        // IN_PROGRESS 게시가 생성된 뒤 인스타그램 API가 실패하면
+        // 콘텐츠 상태가 멈춰 있지 않도록 해당 게시를 FAILED로 보상 처리해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        ContentImage image = createImage(content, "contents/instagram.png");
+        UserSocialAccount account = createInstagramAccount(user, true, LocalDateTime.now().plusDays(1));
+        ContentPost inProgressPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .build();
+        InstagramPublishRequest request = createPublishRequest(content.getId());
+        CustomException apiException = new CustomException(ErrorCode.INSTAGRAM_API_ERROR, "container creation failed");
+
+        given(contentRepository.findById(content.getId())).willReturn(Optional.of(content));
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM")).willReturn(Optional.of(account));
+        given(contentImageRepository.findByContentId(content.getId())).willReturn(List.of(image));
+        given(publishPostService.createInProgressPost(content, ContentPlatform.INSTAGRAM)).willReturn(inProgressPost);
+        given(gcsService.generateSignedUrl("contents/instagram.png")).willReturn("https://signed.test/instagram.png");
+        given(instagramClient.createMediaContainer(
+                "ig-user-id",
+                "long-lived-token",
+                "https://signed.test/instagram.png",
+                "Instagram caption\n\n#fresh #sale",
+                false
+        )).willThrow(apiException);
+
+        // when
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> instagramService.publish(user, request)
+        );
+
+        // then
+        assertThat(exception).isSameAs(apiException);
+        then(publishPostService).should().failPost(inProgressPost.getId());
+        then(publishPostService).should(never()).completePost(any(UUID.class), any(), any(), any(LocalDateTime.class));
+    }
+
+    private User createUser(UUID id, String email) {
+        User user = new User(email, "Test User", "google", id.toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Content createContent(User user) {
+        GenerationRequest generationRequest = GenerationRequest.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .concept("new menu")
+                .build();
+        return Content.builder()
+                .id(UUID.randomUUID())
+                .generationRequest(generationRequest)
+                .instagramText("Instagram caption")
+                .instagramHashtags(List.of("#fresh", "#sale"))
+                .build();
+    }
+
+    private ContentImage createImage(Content content, String url) {
+        return ContentImage.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .inputImageId(UUID.randomUUID())
+                .url(url)
+                .build();
+    }
+
+    private UserSocialAccount createInstagramAccount(User user, boolean valid, LocalDateTime expiresAt) {
+        UserSocialAccount account = new UserSocialAccount();
+        account.setUser(user);
+        account.setPlatform("INSTAGRAM");
+        account.setSocialUserId("ig-user-id");
+        account.setUsername("today_store");
+        account.setAccessToken("long-lived-token");
+        account.setTokenExpiresAt(expiresAt);
+        account.setIsValid(valid);
+        return account;
+    }
+
+    private InstagramPublishRequest createPublishRequest(UUID contentId) {
+        InstagramPublishRequest request = new InstagramPublishRequest();
+        request.setContentId(contentId);
+        return request;
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/common/util/AesEncryptorTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/util/AesEncryptorTest.java
@@ -1,0 +1,84 @@
+package today_store.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AES 암호화 유틸 테스트")
+class AesEncryptorTest {
+
+    @Test
+    @DisplayName("토큰 암호화와 복호화")
+    void shouldEncryptAndDecryptToken() {
+        // 인스타그램 access token은 AES-GCM으로 저장되므로 암호문에 원문이 노출되지 않고
+        // 복호화 시 원래 토큰 값을 정확히 복원해야 한다.
+
+        // given
+        AesEncryptor aesEncryptor = new AesEncryptor("12345678901234567890123456789012");
+
+        // when
+        String encryptedToken = aesEncryptor.encrypt("instagram-access-token");
+        String decryptedToken = aesEncryptor.decrypt(encryptedToken);
+
+        // then
+        assertThat(encryptedToken).isNotEqualTo("instagram-access-token");
+        assertThat(decryptedToken).isEqualTo("instagram-access-token");
+    }
+
+    @Test
+    @DisplayName("매번 다른 IV 사용")
+    void shouldProduceDifferentCiphertextForSamePlainText() {
+        // AES-GCM 암호화는 매번 새로운 IV를 사용해야 하므로
+        // 같은 토큰을 반복 저장해도 동일한 암호문으로 재사용 패턴이 노출되지 않아야 한다.
+
+        // given
+        AesEncryptor aesEncryptor = new AesEncryptor("12345678901234567890123456789012");
+
+        // when
+        String first = aesEncryptor.encrypt("instagram-access-token");
+        String second = aesEncryptor.encrypt("instagram-access-token");
+
+        // then
+        assertThat(first).isNotEqualTo(second);
+        assertThat(aesEncryptor.decrypt(first)).isEqualTo("instagram-access-token");
+        assertThat(aesEncryptor.decrypt(second)).isEqualTo("instagram-access-token");
+    }
+
+    @Test
+    @DisplayName("null 입력 보존")
+    void shouldReturnNullWhenInputIsNull() {
+        // JPA 변환 경로에서 null 토큰 값이 전달될 수 있으므로
+        // 암호화를 시도하거나 예외를 던지지 않고 null을 그대로 보존해야 한다.
+
+        // given
+        AesEncryptor aesEncryptor = new AesEncryptor("12345678901234567890123456789012");
+
+        // when
+        String encrypted = aesEncryptor.encrypt(null);
+        String decrypted = aesEncryptor.decrypt(null);
+
+        // then
+        assertThat(encrypted).isNull();
+        assertThat(decrypted).isNull();
+    }
+
+    @Test
+    @DisplayName("잘못된 키 길이 거부")
+    void shouldRejectInvalidKeyLength() {
+        // AES-256은 secret key가 정확히 32자여야 하므로
+        // 저장된 데이터를 복호화할 수 없는 설정으로 앱이 실행되지 않게 빠르게 실패해야 한다.
+
+        // given
+
+        // when
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> new AesEncryptor("short-key")
+        );
+
+        // then
+        assertThat(exception.getMessage()).isEqualTo("Encryption secret key must be 32 characters long for AES-256");
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/publish/service/ManualPublishServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/publish/service/ManualPublishServiceTest.java
@@ -1,0 +1,316 @@
+package today_store.content.publish.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import today_store.authentication.entity.User;
+import today_store.authentication.exception.AccessDeniedToResourceException;
+import today_store.common.gcs.GcsService;
+import today_store.content.content.entity.Content;
+import today_store.content.content.entity.ContentImage;
+import today_store.content.content.entity.ContentPlatform;
+import today_store.content.content.entity.ContentPost;
+import today_store.content.content.entity.PublishStatus;
+import today_store.content.content.exception.ContentNotFoundException;
+import today_store.content.content.repository.ContentImageRepository;
+import today_store.content.content.repository.ContentPostRepository;
+import today_store.content.content.repository.ContentRepository;
+import today_store.content.publish.dto.CompleteManualPublishRequest;
+import today_store.content.publish.dto.CompleteManualPublishResponse;
+import today_store.content.publish.dto.StartManualPublishRequest;
+import today_store.content.publish.dto.StartManualPublishResponse;
+import today_store.content.request.entity.GenerationRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("수동 게시 서비스 테스트")
+class ManualPublishServiceTest {
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    @Mock
+    private ContentPostRepository contentPostRepository;
+
+    @Mock
+    private ContentImageRepository contentImageRepository;
+
+    @Mock
+    private GcsService gcsService;
+
+    private ManualPublishService manualPublishService;
+
+    @BeforeEach
+    void setUp() {
+        manualPublishService = new ManualPublishService(
+                contentRepository,
+                contentPostRepository,
+                contentImageRepository,
+                gcsService
+        );
+    }
+
+    @Test
+    @DisplayName("수동 게시 시작 시 게시 초안과 플랫폼 데이터를 반환")
+    void shouldStartManualPublishWithPlatformPayloadAndSignedImages() {
+        // 수동 게시 시작 응답은 외부 업로드 화면에 전달되는 계약이므로
+        // IN_PROGRESS 게시 초안을 생성하거나 재사용하고 플랫폼별 문구, 태그,
+        // signed 이미지 URL, 이전 게시 정보를 함께 반환해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        StartManualPublishRequest request = new StartManualPublishRequest(content.getId(), ContentPlatform.INSTAGRAM);
+        UUID postId = UUID.randomUUID();
+        ContentPost inProgressPost = ContentPost.builder()
+                .id(postId)
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .status(PublishStatus.IN_PROGRESS)
+                .build();
+        LocalDateTime lastPublishedAt = LocalDateTime.of(2026, 4, 20, 12, 30);
+        ContentPost completedPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .status(PublishStatus.COMPLETED)
+                .publishedAt(lastPublishedAt)
+                .build();
+        ContentImage firstImage = createImage(content, "contents/first.png");
+        ContentImage secondImage = createImage(content, "contents/second.png");
+
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+        given(contentPostRepository.findFirstByContentAndPlatformAndStatusOrderByPublishedAtDesc(
+                content, ContentPlatform.INSTAGRAM, PublishStatus.IN_PROGRESS
+        )).willReturn(Optional.empty());
+        given(contentPostRepository.save(argThat(post ->
+                post.getContent() == content
+                        && post.getPlatform() == ContentPlatform.INSTAGRAM
+                        && post.getStatus() == PublishStatus.IN_PROGRESS
+        ))).willReturn(inProgressPost);
+        given(contentPostRepository.findFirstByContentAndPlatformAndStatusOrderByPublishedAtDesc(
+                content, ContentPlatform.INSTAGRAM, PublishStatus.COMPLETED
+        )).willReturn(Optional.of(completedPost));
+        given(contentImageRepository.findByContentOrderByCreatedAtAsc(content)).willReturn(List.of(firstImage, secondImage));
+        given(gcsService.generateSignedUrl("contents/first.png")).willReturn("https://signed.test/first.png");
+        given(gcsService.generateSignedUrl("contents/second.png")).willReturn("https://signed.test/second.png");
+
+        // when
+        StartManualPublishResponse response = manualPublishService.startManualPublish(user, request);
+
+        // then
+        assertThat(response.getPostId()).isEqualTo(postId);
+        assertThat(response.getText()).isEqualTo("Instagram caption");
+        assertThat(response.getTags()).containsExactly("#fresh", "#sale");
+        assertThat(response.getImageUrls()).containsExactly("https://signed.test/first.png", "https://signed.test/second.png");
+        assertThat(response.getStatus()).isEqualTo(PublishStatus.IN_PROGRESS);
+        assertThat(response.isAlreadyPublished()).isTrue();
+        assertThat(response.getLastPublishedAt()).isEqualTo(lastPublishedAt);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠의 수동 게시 시작 거부")
+    void shouldThrowContentNotFoundWhenStartingManualPublishForMissingContent() {
+        // 삭제되었거나 존재하지 않는 콘텐츠로 수동 게시 세션을 열면
+        // 유효하지 않은 리소스에 대한 외부 업로드가 계속될 수 있으므로 거부해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        UUID missingContentId = UUID.randomUUID();
+        StartManualPublishRequest request = new StartManualPublishRequest(missingContentId, ContentPlatform.NAVER);
+
+        given(contentRepository.findByIdAndIsDeletedFalse(missingContentId)).willReturn(Optional.empty());
+
+        // when
+        ContentNotFoundException exception = assertThrows(
+                ContentNotFoundException.class,
+                () -> manualPublishService.startManualPublish(user, request)
+        );
+
+        // then
+        assertThat(exception).isNotNull();
+        then(contentPostRepository).should(never()).save(any(ContentPost.class));
+        then(contentImageRepository).should(never()).findByContentOrderByCreatedAtAsc(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("수동 게시 시작 시 소유자 검증")
+    void shouldThrowAccessDeniedWhenStartingManualPublishForAnotherUsersContent() {
+        // 콘텐츠 소유권은 수동 게시의 주요 권한 경계이므로
+        // 다른 사용자는 게시 ID, 문구, 태그, signed 이미지 URL을 받을 수 없어야 한다.
+
+        // given
+        User owner = createUser(UUID.randomUUID(), "owner@example.com");
+        User requester = createUser(UUID.randomUUID(), "requester@example.com");
+        Content content = createContent(owner);
+        StartManualPublishRequest request = new StartManualPublishRequest(content.getId(), ContentPlatform.INSTAGRAM);
+
+        given(contentRepository.findByIdAndIsDeletedFalse(content.getId())).willReturn(Optional.of(content));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> manualPublishService.startManualPublish(requester, request)
+        );
+
+        // then
+        assertThat(exception).isNotNull();
+        then(contentPostRepository).should(never()).save(any(ContentPost.class));
+        then(gcsService).should(never()).generateSignedUrl(any());
+    }
+
+    @Test
+    @DisplayName("수동 게시 완료 시 게시 완료 상태로 저장")
+    void shouldCompleteManualPublishWithPostUrl() {
+        // 수동 게시 완료는 외부 게시 URL과 게시 시간을 기록하여
+        // 콘텐츠 목록에서 게시 성공 상태를 확인할 수 있게 해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        ContentPost contentPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.NAVER)
+                .status(PublishStatus.IN_PROGRESS)
+                .build();
+        CompleteManualPublishRequest request = new CompleteManualPublishRequest(
+                contentPost.getId(),
+                PublishStatus.COMPLETED,
+                "https://blog.naver.com/today-store/post"
+        );
+
+        given(contentPostRepository.findById(contentPost.getId())).willReturn(Optional.of(contentPost));
+        given(contentPostRepository.save(contentPost)).willReturn(contentPost);
+
+        // when
+        CompleteManualPublishResponse response = manualPublishService.completeManualPublish(user, request);
+
+        // then
+        assertThat(response.getPostId()).isEqualTo(contentPost.getId());
+        assertThat(response.getStatus()).isEqualTo(PublishStatus.COMPLETED);
+        assertThat(response.getPublishedAt()).isNotNull();
+        assertThat(contentPost.getPostUrl()).isEqualTo("https://blog.naver.com/today-store/post");
+        then(contentPostRepository).should().save(contentPost);
+    }
+
+    @Test
+    @DisplayName("수동 게시 실패 시 실패 상태로 저장")
+    void shouldFailManualPublishAndClearPublicationFields() {
+        // 외부 수동 업로드가 실패하면 게시 상태를 FAILED로 저장하고
+        // 오래된 URL이나 게시 시간이 남지 않도록 정리해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        Content content = createContent(user);
+        ContentPost contentPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.KARROT)
+                .status(PublishStatus.IN_PROGRESS)
+                .postUrl("https://stale.example/post")
+                .publishedAt(LocalDateTime.of(2026, 4, 20, 9, 0))
+                .build();
+        CompleteManualPublishRequest request = new CompleteManualPublishRequest(
+                contentPost.getId(),
+                PublishStatus.FAILED,
+                "https://ignored.example/post"
+        );
+
+        given(contentPostRepository.findById(contentPost.getId())).willReturn(Optional.of(contentPost));
+        given(contentPostRepository.save(contentPost)).willReturn(contentPost);
+
+        // when
+        CompleteManualPublishResponse response = manualPublishService.completeManualPublish(user, request);
+
+        // then
+        assertThat(response.getPostId()).isEqualTo(contentPost.getId());
+        assertThat(response.getStatus()).isEqualTo(PublishStatus.FAILED);
+        assertThat(response.getPublishedAt()).isNull();
+        assertThat(contentPost.getPostUrl()).isNull();
+        assertThat(contentPost.getPublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("수동 게시 완료 시 소유자 검증")
+    void shouldThrowAccessDeniedWhenCompletingAnotherUsersPost() {
+        // 완료 요청은 게시 상태를 변경하므로 수동 게시 시작 시점뿐 아니라
+        // postId 기준으로도 다시 소유권을 검증해야 한다.
+
+        // given
+        User owner = createUser(UUID.randomUUID(), "owner@example.com");
+        User requester = createUser(UUID.randomUUID(), "requester@example.com");
+        Content content = createContent(owner);
+        ContentPost contentPost = ContentPost.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .platform(ContentPlatform.INSTAGRAM)
+                .status(PublishStatus.IN_PROGRESS)
+                .build();
+        CompleteManualPublishRequest request = new CompleteManualPublishRequest(
+                contentPost.getId(),
+                PublishStatus.COMPLETED,
+                "https://instagram.com/p/test"
+        );
+
+        given(contentPostRepository.findById(contentPost.getId())).willReturn(Optional.of(contentPost));
+
+        // when
+        AccessDeniedToResourceException exception = assertThrows(
+                AccessDeniedToResourceException.class,
+                () -> manualPublishService.completeManualPublish(requester, request)
+        );
+
+        // then
+        assertThat(exception).isNotNull();
+        then(contentPostRepository).should(never()).save(any(ContentPost.class));
+    }
+
+    private User createUser(UUID id, String email) {
+        User user = new User(email, "Test User", "google", id.toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Content createContent(User user) {
+        GenerationRequest generationRequest = GenerationRequest.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .concept("new menu")
+                .build();
+        return Content.builder()
+                .id(UUID.randomUUID())
+                .generationRequest(generationRequest)
+                .instagramText("Instagram caption")
+                .instagramHashtags(List.of("#fresh", "#sale"))
+                .naverText("Naver content")
+                .naverKeywords(List.of("fresh", "sale"))
+                .karrotText("Karrot content")
+                .karrotTags(List.of("nearby", "deal"))
+                .build();
+    }
+
+    private ContentImage createImage(Content content, String url) {
+        return ContentImage.builder()
+                .id(UUID.randomUUID())
+                .content(content)
+                .inputImageId(UUID.randomUUID())
+                .url(url)
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/user/service/UserSocialAccountServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/user/service/UserSocialAccountServiceTest.java
@@ -1,0 +1,162 @@
+package today_store.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import today_store.authentication.entity.User;
+import today_store.common.exception.CustomException;
+import today_store.common.exception.ErrorCode;
+import today_store.user.entity.UserSocialAccount;
+import today_store.user.repository.UserSocialAccountRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("사용자 소셜 계정 서비스 테스트")
+class UserSocialAccountServiceTest {
+
+    @Mock
+    private UserSocialAccountRepository userSocialAccountRepository;
+
+    private UserSocialAccountService userSocialAccountService;
+
+    @BeforeEach
+    void setUp() {
+        userSocialAccountService = new UserSocialAccountService(userSocialAccountRepository);
+    }
+
+    @Test
+    @DisplayName("소셜 계정 최초 연결 시 계정 생성")
+    void shouldCreateSocialAccountWhenNoExistingLinkExists() {
+        // 최초 인스타그램 OAuth 연결은 요청 사용자에게 플랫폼 식별자,
+        // 사용자명, 장기 토큰, 만료 시간, 유효 상태를 저장해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 5, 1, 10, 0);
+
+        given(userSocialAccountRepository.findByPlatformAndSocialUserId("INSTAGRAM", "ig-user-id"))
+                .willReturn(Optional.empty());
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM"))
+                .willReturn(Optional.empty());
+
+        // when
+        userSocialAccountService.linkAccount(
+                user,
+                "INSTAGRAM",
+                "ig-user-id",
+                "today_store",
+                "long-lived-token",
+                expiresAt
+        );
+
+        // then
+        ArgumentCaptor<UserSocialAccount> captor = ArgumentCaptor.forClass(UserSocialAccount.class);
+        then(userSocialAccountRepository).should().save(captor.capture());
+        UserSocialAccount savedAccount = captor.getValue();
+        assertThat(savedAccount.getUser()).isSameAs(user);
+        assertThat(savedAccount.getPlatform()).isEqualTo("INSTAGRAM");
+        assertThat(savedAccount.getSocialUserId()).isEqualTo("ig-user-id");
+        assertThat(savedAccount.getUsername()).isEqualTo("today_store");
+        assertThat(savedAccount.getAccessToken()).isEqualTo("long-lived-token");
+        assertThat(savedAccount.getTokenExpiresAt()).isEqualTo(expiresAt);
+        assertThat(savedAccount.getIsValid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("동일 사용자 계정 재연결 시 기존 계정 갱신")
+    void shouldUpdateExistingAccountForSameUserAndPlatform() {
+        // 같은 사용자의 인스타그램 계정을 다시 인증하면 중복 행을 만들지 않고
+        // 기존 계정의 식별자, 사용자명, 토큰, 만료 시간, 유효 상태를 갱신해야 한다.
+
+        // given
+        User user = createUser(UUID.randomUUID(), "owner@example.com");
+        UserSocialAccount existingAccount = new UserSocialAccount();
+        existingAccount.setUser(user);
+        existingAccount.setPlatform("INSTAGRAM");
+        existingAccount.setSocialUserId("old-ig-user-id");
+        existingAccount.setUsername("old_username");
+        existingAccount.setAccessToken("old-token");
+        existingAccount.setTokenExpiresAt(LocalDateTime.of(2026, 4, 1, 10, 0));
+        existingAccount.setIsValid(false);
+        LocalDateTime newExpiresAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+        given(userSocialAccountRepository.findByPlatformAndSocialUserId("INSTAGRAM", "ig-user-id"))
+                .willReturn(Optional.empty());
+        given(userSocialAccountRepository.findByUserAndPlatform(user, "INSTAGRAM"))
+                .willReturn(Optional.of(existingAccount));
+
+        // when
+        userSocialAccountService.linkAccount(
+                user,
+                "INSTAGRAM",
+                "ig-user-id",
+                "today_store",
+                "new-long-lived-token",
+                newExpiresAt
+        );
+
+        // then
+        then(userSocialAccountRepository).should().save(existingAccount);
+        assertThat(existingAccount.getSocialUserId()).isEqualTo("ig-user-id");
+        assertThat(existingAccount.getUsername()).isEqualTo("today_store");
+        assertThat(existingAccount.getAccessToken()).isEqualTo("new-long-lived-token");
+        assertThat(existingAccount.getTokenExpiresAt()).isEqualTo(newExpiresAt);
+        assertThat(existingAccount.getIsValid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 소셜 계정 연결 거부")
+    void shouldRejectSocialAccountAlreadyLinkedToAnotherUser() {
+        // 하나의 인스타그램 식별자가 두 사용자에게 연결되면
+        // 다른 사용자의 연결 계정으로 게시할 수 있으므로 반드시 거부해야 한다.
+
+        // given
+        User requester = createUser(UUID.randomUUID(), "requester@example.com");
+        User otherUser = createUser(UUID.randomUUID(), "other@example.com");
+        UserSocialAccount existingAccount = new UserSocialAccount();
+        existingAccount.setUser(otherUser);
+        existingAccount.setPlatform("INSTAGRAM");
+        existingAccount.setSocialUserId("ig-user-id");
+
+        given(userSocialAccountRepository.findByPlatformAndSocialUserId("INSTAGRAM", "ig-user-id"))
+                .willReturn(Optional.of(existingAccount));
+
+        // when
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> userSocialAccountService.linkAccount(
+                        requester,
+                        "INSTAGRAM",
+                        "ig-user-id",
+                        "today_store",
+                        "long-lived-token",
+                        LocalDateTime.of(2026, 5, 1, 10, 0)
+                )
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INSTAGRAM_ALREADY_LINKED);
+        then(userSocialAccountRepository).should(never()).findByUserAndPlatform(any(User.class), any());
+        then(userSocialAccountRepository).should(never()).save(any(UserSocialAccount.class));
+    }
+
+    private User createUser(UUID id, String email) {
+        User user = new User(email, "Test User", "google", id.toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #60 

## As-Is
- 컨텐츠 업로드 및 인스타그램 게시 연동 기능에 대한 서비스 레벨 회귀 테스트가 부족
- OAuth 제공자가 이메일을 내려주지 않는 경우의 fallback 이메일 생성 동작이 테스트로 보호되지 않음
- 인스타그램 소셜 계정 연결, 토큰 암호화, 게시 실패 보상 처리에 대한 테스트가 부족

## To-Be
- OAuth 이메일 누락 시 providerId/provider 기반 대체 이메일 생성 테스트를 추가
- 수동 게시 시작/완료/실패 및 소유권 검증 테스트를 추가
- 인스타그램 인증, 단일 이미지 게시, 다중 이미지 캐러셀 게시, 토큰 만료, API 실패 보상 처리 테스트를 추가
- 사용자 소셜 계정 최초 연결/갱신/타 사용자 계정 충돌 테스트를 추가
- AES-GCM 토큰 암복호화, random IV, null 처리, 잘못된 키 길이 검증 테스트를 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
