### PR TITLE
[Build] 보안 취약 의존성 버전 업데이트

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -29,6 +29,7 @@ ext {
 	set('springCloudVersion', "2025.0.1")
 	set('jackson-bom.version', "2.21.1")
 	set('tomcat.version', "10.1.54")
+	set('postgresql.version', "42.7.11")
 }
 
 dependencies {

--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.13'
+	id 'org.springframework.boot' version '3.5.14'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -15,6 +15,10 @@ java {
 }
 
 configurations {
+	configureEach {
+		exclude group: 'io.netty', module: 'netty-transport-native-epoll'
+	}
+
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -29,6 +33,7 @@ ext {
 	set('springCloudVersion', "2025.0.1")
 	set('jackson-bom.version', "2.21.1")
 	set('tomcat.version', "10.1.54")
+	set('netty.version', "4.1.133.Final")
 	set('postgresql.version', "42.7.11")
 }
 


### PR DESCRIPTION
## Issue Number
closed #70 

## As-Is
- Trivy 스캔에서 Spring Boot, Netty, PostgreSQL JDBC 관련 HIGH 등급 취약점이 감지
- Spring Boot 3.5.13, Netty 4.1.132.Final, PostgreSQL JDBC 42.7.10 버전이 사용 중

## To-Be
- Spring Boot를 3.5.14로 업데이트하여 CVE-2026-40973에 대응
- PostgreSQL JDBC를 42.7.11로 업데이트하여 CVE-2026-42198에 대응
- Netty를 4.1.133.Final로 업데이트하여 관련 취약점에 대응
- netty-transport-native-epoll 제외 처리하여 취약점에 대응

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- CVE-2026-40973
- CVE-2026-42198
- CVE-2026-42579
- CVE-2026-42583
- CVE-2026-42584
- CVE-2026-42577