### PR TITLE
Fix : backend - 사용자 프로필 이메일 변경 추가

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/entity/User.java
@@ -79,4 +79,9 @@ public class User {
         }
     }
 
+    public void updateEmail(String email) {
+        if (email != null && !email.isBlank()) {
+            this.email = email;
+        }
+    }
 }

--- a/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
+++ b/backend-spring/today-store/src/main/java/today_store/authentication/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmail(String email);
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
+    boolean existsByEmail(String email);
 }

--- a/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     // User
     INVALID_NAME_FORMAT(HttpStatus.BAD_REQUEST, "U001", "Invalid name format"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "Email is already in use"),
 
     // Store
     STORE_REQUIRED_FIELDS_MISSING(HttpStatus.BAD_REQUEST, "S001", "Store name and business type are required"),

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileRequest.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileRequest.java
@@ -1,5 +1,6 @@
 package today_store.user.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -15,4 +16,7 @@ public class UpdateUserProfileRequest {
     @NotBlank(message = "Name is required")
     @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
     private String name;
+
+    @Email(message = "Invalid email format")
+    private String email;
 }

--- a/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/dto/UpdateUserProfileResponse.java
@@ -15,11 +15,23 @@ import java.util.UUID;
 @AllArgsConstructor
 public class UpdateUserProfileResponse {
     private UUID id;
+    private String email;
+    private String name;
+    private String accessToken;
+    private String refreshToken;
     private LocalDateTime updatedAt;
 
     public static UpdateUserProfileResponse from(User user) {
+        return from(user, null, null);
+    }
+
+    public static UpdateUserProfileResponse from(User user, String accessToken, String refreshToken) {
         return UpdateUserProfileResponse.builder()
                 .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .updatedAt(user.getUpdatedAt())
                 .build();
     }

--- a/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
+++ b/backend-spring/today-store/src/main/java/today_store/user/service/UserService.java
@@ -1,10 +1,15 @@
 package today_store.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import today_store.authentication.entity.RefreshToken;
 import today_store.authentication.entity.User;
+import today_store.authentication.jwt.JwtTokenProvider;
+import today_store.authentication.repository.RefreshTokenRepository;
 import today_store.authentication.repository.UserRepository;
 import today_store.common.exception.CustomException;
 import today_store.common.exception.ErrorCode;
@@ -17,6 +22,8 @@ import today_store.user.dto.UserProfileResponse;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional(readOnly = true)
     public User getUser(Authentication authentication) {
@@ -38,11 +45,45 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        boolean emailChanged = false;
+        String newEmail = request.getEmail();
+
+        // 1. 이메일 변경 여부 확인 및 중복 검증
+        if (newEmail != null && !newEmail.isBlank() && !newEmail.equals(email)) {
+            if (userRepository.existsByEmail(newEmail)) {
+                throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+            }
+            user.updateEmail(newEmail);
+            emailChanged = true;
+        }
+
+        // 2. 이름 업데이트
         user.updateName(request.getName());
 
+        // 3. 변경 사항 저장 (Flush를 통해 updatedAt 갱신 및 DB 반영 확인)
         User updatedUser = userRepository.saveAndFlush(user);
 
-        return UpdateUserProfileResponse.from(updatedUser);
+        String newAccessToken = null;
+        String newRefreshToken = null;
+
+        // 4. 이메일이 변경된 경우 인증 식별자(Subject)가 변경되었으므로 토큰 재발급
+        if (emailChanged) {
+            Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+            // 새로운 이메일을 Subject로 하는 새로운 인증 객체 생성
+            Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                    updatedUser.getEmail(),
+                    null,
+                    currentAuth != null ? currentAuth.getAuthorities() : null
+            );
+
+            newAccessToken = jwtTokenProvider.createAccessToken(newAuth);
+            newRefreshToken = jwtTokenProvider.createRefreshToken(newAuth);
+
+            // Redis에 저장된 Refresh Token 갱신
+            refreshTokenRepository.save(new RefreshToken(updatedUser.getId(), newRefreshToken));
+        }
+
+        return UpdateUserProfileResponse.from(updatedUser, newAccessToken, newRefreshToken);
     }
 }
 

--- a/backend-spring/today-store/src/test/java/today_store/user/service/UserServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/user/service/UserServiceTest.java
@@ -18,6 +18,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 import today_store.authentication.entity.User;
+import today_store.authentication.jwt.JwtTokenProvider;
+import today_store.authentication.repository.RefreshTokenRepository;
 import today_store.authentication.repository.UserRepository;
 import today_store.common.exception.CustomException;
 import today_store.common.exception.ErrorCode;
@@ -32,11 +34,17 @@ class UserServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository);
+        userService = new UserService(userRepository, jwtTokenProvider, refreshTokenRepository);
     }
 
     @Test


### PR DESCRIPTION
## Issue Number
closed #75 

## As-Is
사용자 프로필 업데이트 API에 이메일 필드 업데이트를 지원하지 않음 
-> OAuth 회원가입에서 이메일 필드가 비어있는 경우 임의의 이메일로 유지됨 
-> 이미지 작업 결과 알림 메일 전송 시 유효하지 않은 이메일로 전송하게 됨

## To-Be
- UserService.updateUserProfile : 이메일 변경 가능하도록 수정 및 이메일 변경 시 JWT AT,RT 교체 로직 추가.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- Notion Wiki API 엔드포인트 문서 2.2 항목 업데이트 완료. 