### PR TITLE
[Build] Trivy 대응을 위한 백엔드 이미지 고정 및 CI/CD 액션 업데이트

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Select branch-specific deployment target (develop=dev, main=prod)
       - name: Resolve deployment context
@@ -77,13 +77,13 @@ jobs:
 
       # Set up JDK and Gradle cache
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       # Run backend tests before container build
       - name: Build and test with Gradle
@@ -124,7 +124,7 @@ jobs:
           IMAGE_URI: ${{ steps.image_meta.outputs.image_uri }}
         shell: bash
         run: |
-          docker build -t "$IMAGE_URI" backend-spring/today-store
+          docker build --pull -t "$IMAGE_URI" backend-spring/today-store
 
       # Scan Docker image for HIGH/CRITICAL vulnerabilities
       - name: Trivy security scan

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,18 +26,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up JDK for Spring Boot build
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       # Enable Gradle cache and build optimizations
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       # Run backend tests and create executable jar
       - name: Build and test with Gradle
@@ -48,7 +48,7 @@ jobs:
 
       # Verify Docker image
       - name: Docker build test
-        run: docker build -t backend-ci-test:latest backend-spring/today-store
+        run: docker build --pull -t backend-ci-test:latest backend-spring/today-store
 
       # Scan Docker image for HIGH/CRITICAL vulnerabilities
       - name: Trivy security scan

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -31,11 +31,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up JDK for Android build
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set up JDK for Android build
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'

--- a/backend-spring/today-store/Dockerfile
+++ b/backend-spring/today-store/Dockerfile
@@ -9,7 +9,7 @@ COPY src src
 
 RUN chmod +x gradlew && ./gradlew --no-daemon clean bootJar
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-noble
 WORKDIR /app
 
 COPY --from=build /workspace/build/libs/*.jar app.jar


### PR DESCRIPTION
## Issue Number
closed #80 

## As-Is
- `backend_ci`의 Trivy scan에서 `/usr/bin/pebble` Go 바이너리의 stdlib 취약점이 감지되어 workflow가 실패
- 백엔드 Dockerfile이 `eclipse-temurin:21-jre` floating tag를 사용하고 있어 베이스 이미지 계열 변경에 따라 CI 보안 스캔 결과가 달라짐
- GitHub Actions에서 Node.js 20 기반 액션 사용 경고가 함께 발생

## To-Be
- 백엔드 Docker 런타임 이미지를 `eclipse-temurin:21-jre-noble`로 고정
- 백엔드 CI/CD의 `docker build`에 `--pull` 옵션을 추가
- GitHub Actions의 주요 액션을 Node.js 24 대응 버전으로 업데이트
  - `actions/checkout@v4` → `actions/checkout@v5`
  - `actions/setup-java@v4` → `actions/setup-java@v5`
  - `gradle/actions/setup-gradle@v4` → `gradle/actions/setup-gradle@v5`

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
