### PR TITLE
[Test] 이메일 알림 및 프로필 이메일 변경 테스트 코드 보강

### DIFF
--- a/backend-spring/today-store/build.gradle
+++ b/backend-spring/today-store/build.gradle
@@ -32,7 +32,7 @@ ext {
 	set('springCloudGcpVersion', "7.4.2")
 	set('springCloudVersion', "2025.0.1")
 	set('jackson-bom.version', "2.21.1")
-	set('tomcat.version', "10.1.54")
+	set('tomcat.version', "10.1.55")
 	set('netty.version', "4.1.133.Final")
 	set('postgresql.version', "42.7.11")
 }
@@ -53,7 +53,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.resend:resend-java:+'
 
-	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0")
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.7")
 
 	implementation 'org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/backend-spring/today-store/src/test/java/today_store/common/notification/NotificationMapperTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/notification/NotificationMapperTest.java
@@ -1,0 +1,48 @@
+package today_store.common.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("알림 매퍼 테스트")
+class NotificationMapperTest {
+
+    private final NotificationMapper notificationMapper = new NotificationMapper();
+
+    @Test
+    @DisplayName("작업 타입 한글 변환")
+    void shouldTranslateTaskType() {
+        // 외부 AI 모델 식별자를 사용자에게 노출하지 않고 알림용 한글 작업명으로 변환해야 한다.
+
+        // given
+
+        // when & then
+        assertThat(notificationMapper.translateTaskType("gemini-2.5-flash")).isEqualTo("콘텐츠 생성");
+        assertThat(notificationMapper.translateTaskType("COMFY_UI_VARIATION_V1")).isEqualTo("이미지 변형");
+        assertThat(notificationMapper.translateTaskType(null)).isEqualTo("AI 작업");
+        assertThat(notificationMapper.translateTaskType("unknown-model")).isEqualTo("AI 작업");
+    }
+
+    @Test
+    @DisplayName("에러 메시지 한글 변환")
+    void shouldTranslateErrorMessage() {
+        // 시스템 내부 오류 문구를 그대로 보내지 않고 사용자가 이해할 수 있는 안전한 메시지로 변환해야 한다.
+
+        // given
+
+        // when & then
+        assertThat(notificationMapper.translateErrorMessage(null))
+                .isEqualTo("알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+        assertThat(notificationMapper.translateErrorMessage("request timed out"))
+                .isEqualTo("작업 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
+        assertThat(notificationMapper.translateErrorMessage("Verification failed"))
+                .isEqualTo("작업 결과 검증에 실패했습니다. 관리자에게 문의해 주세요.");
+        assertThat(notificationMapper.translateErrorMessage("failed to initiate comfy task"))
+                .isEqualTo("AI 서비스 요청 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+        assertThat(notificationMapper.translateErrorMessage("upload variation failed"))
+                .isEqualTo("이미지 처리 또는 저장 중 오류가 발생했습니다.");
+        assertThat(notificationMapper.translateErrorMessage("unexpected provider message"))
+                .isEqualTo("처리 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/common/notification/TaskNotificationListenerTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/common/notification/TaskNotificationListenerTest.java
@@ -1,0 +1,117 @@
+package today_store.common.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.IContext;
+import today_store.authentication.entity.User;
+import today_store.content.content.entity.ApiLog;
+import today_store.content.content.entity.ApiStatus;
+import today_store.content.content.event.TaskCompletedEvent;
+import today_store.content.request.entity.GenerationRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("작업 알림 리스너 테스트")
+class TaskNotificationListenerTest {
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private NotificationMapper notificationMapper;
+
+    private TaskNotificationListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new TaskNotificationListener(emailService, templateEngine, notificationMapper);
+    }
+
+    @Test
+    @DisplayName("작업 완료 이메일 발송")
+    void shouldSendEmailWhenTaskCompletedEventIsHandled() {
+        // 작업 완료 이벤트를 받으면 내부 모델명과 오류 메시지를 알림 문구로 변환하고 템플릿 결과를 사용자 이메일로 발송해야 한다.
+
+        // given
+        TaskCompletedEvent event = new TaskCompletedEvent(this, createApiLog(ApiStatus.ERROR, "COMFY_UI_VARIATION_V1", "request timed out"));
+        given(notificationMapper.translateTaskType("COMFY_UI_VARIATION_V1")).willReturn("이미지 변형");
+        given(notificationMapper.translateErrorMessage("request timed out")).willReturn("작업 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
+        given(templateEngine.process(eq("mail/task-notification"), org.mockito.ArgumentMatchers.any(IContext.class)))
+                .willReturn("<html>알림 본문</html>");
+
+        // when
+        listener.handleTaskCompletedEvent(event);
+
+        // then
+        ArgumentCaptor<IContext> contextCaptor = ArgumentCaptor.forClass(IContext.class);
+        then(templateEngine).should().process(eq("mail/task-notification"), contextCaptor.capture());
+        assertThat(contextCaptor.getValue().getVariable("taskType")).isEqualTo("이미지 변형");
+        assertThat(contextCaptor.getValue().getVariable("status")).isEqualTo("ERROR");
+        assertThat(contextCaptor.getValue().getVariable("errorMessage"))
+                .isEqualTo("작업 시간이 초과되었습니다. 잠시 후 다시 시도해 주세요.");
+        assertThat(contextCaptor.getValue().getVariable("submittedAt")).isEqualTo("2026-05-15 09:30:00");
+        then(emailService).should().sendTaskNotification(
+                "owner@example.com",
+                "[알림] 이미지 변형 작업이 완료되었습니다 (ERROR)",
+                "<html>알림 본문</html>"
+        );
+    }
+
+    @Test
+    @DisplayName("알림 처리 예외 격리")
+    void shouldNotSendEmailWhenTemplateProcessingFails() {
+        // 알림 템플릿 처리 중 예외가 발생해도 이벤트 처리 예외를 밖으로 전파하지 않고 메인 작업 흐름을 보호해야 한다.
+
+        // given
+        TaskCompletedEvent event = new TaskCompletedEvent(this, createApiLog(ApiStatus.SUCCESS, "gemini-2.5-flash", null));
+        given(notificationMapper.translateTaskType("gemini-2.5-flash")).willReturn("콘텐츠 생성");
+        given(notificationMapper.translateErrorMessage(null)).willReturn("알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+        given(templateEngine.process(eq("mail/task-notification"), org.mockito.ArgumentMatchers.any(IContext.class)))
+                .willThrow(new IllegalStateException("template missing"));
+
+        // when
+        listener.handleTaskCompletedEvent(event);
+
+        // then
+        then(emailService).should(never()).sendTaskNotification(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    private ApiLog createApiLog(ApiStatus status, String model, String errorMessage) {
+        User user = new User("owner@example.com", "테스트 사용자", "google", "provider-id", "https://image.test/profile.png");
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept("테스트 컨셉")
+                .build();
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model(model)
+                .status(ApiStatus.PROCESSING)
+                .build();
+        ReflectionTestUtils.setField(apiLog, "id", UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        ReflectionTestUtils.setField(apiLog, "createdAt", LocalDateTime.of(2026, 5, 15, 9, 30));
+        if (status == ApiStatus.SUCCESS) {
+            apiLog.completeSuccess(null, 0, 0, BigDecimal.ZERO, 0);
+        } else if (status == ApiStatus.ERROR) {
+            apiLog.completeError(errorMessage);
+        }
+        return apiLog;
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/content/event/TaskCompletedEventTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/event/TaskCompletedEventTest.java
@@ -1,0 +1,81 @@
+package today_store.content.content.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import today_store.authentication.entity.User;
+import today_store.content.content.entity.ApiLog;
+import today_store.content.content.entity.ApiStatus;
+import today_store.content.request.entity.GenerationRequest;
+
+@DisplayName("작업 완료 이벤트 테스트")
+class TaskCompletedEventTest {
+
+    @Test
+    @DisplayName("ApiLog 필드 매핑")
+    void shouldMapApiLogFieldsToEvent() {
+        // 이메일 알림 리스너가 별도 조회 없이 사용할 수 있도록 ApiLog의 핵심 정보를 이벤트에 고정해야 한다.
+
+        // given
+        UUID apiLogId = UUID.randomUUID();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 15, 10, 20);
+        User user = new User("owner@example.com", "테스트 사용자", "google", "provider-id", "https://image.test/profile.png");
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept("테스트 컨셉")
+                .build();
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model("COMFY_UI_VARIATION_V1")
+                .status(ApiStatus.PROCESSING)
+                .build();
+        ReflectionTestUtils.setField(apiLog, "id", apiLogId);
+        ReflectionTestUtils.setField(apiLog, "createdAt", createdAt);
+        apiLog.completeError("request timed out");
+
+        // when
+        TaskCompletedEvent event = new TaskCompletedEvent(this, apiLog);
+
+        // then
+        assertThat(event.getApiLogId()).isEqualTo(apiLogId);
+        assertThat(event.getUserEmail()).isEqualTo("owner@example.com");
+        assertThat(event.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(event.getTaskType()).isEqualTo("COMFY_UI_VARIATION_V1");
+        assertThat(event.getErrorMessage()).isEqualTo("request timed out");
+        assertThat(event.getSubmittedAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("성공 이벤트 에러 없음")
+    void shouldKeepErrorMessageNullForSuccessEvent() {
+        // 성공 작업 알림에서는 실패 사유가 없어야 하므로 성공 상태와 null 에러 메시지를 그대로 전달해야 한다.
+
+        // given
+        User user = new User("owner@example.com", "테스트 사용자", "google", "provider-id", "https://image.test/profile.png");
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept("테스트 컨셉")
+                .build();
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model("gemini-2.5-flash")
+                .status(ApiStatus.PROCESSING)
+                .build();
+        ReflectionTestUtils.setField(apiLog, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(apiLog, "createdAt", LocalDateTime.of(2026, 5, 15, 10, 20));
+        apiLog.completeSuccess(null, 0, 0, BigDecimal.ZERO, 0);
+
+        // when
+        TaskCompletedEvent event = new TaskCompletedEvent(this, apiLog);
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        assertThat(event.getTaskType()).isEqualTo("gemini-2.5-flash");
+        assertThat(event.getErrorMessage()).isNull();
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/content/content/service/ComfyWebhookServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/content/content/service/ComfyWebhookServiceTest.java
@@ -1,0 +1,229 @@
+package today_store.content.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import today_store.authentication.entity.User;
+import today_store.common.gcs.GcsService;
+import today_store.common.runcomfy.service.RunComfyService;
+import today_store.content.content.entity.ApiLog;
+import today_store.content.content.entity.ApiStatus;
+import today_store.content.content.entity.InputImageVariation;
+import today_store.content.content.event.TaskCompletedEvent;
+import today_store.content.content.repository.ApiLogRepository;
+import today_store.content.content.repository.InputImageVariationRepository;
+import today_store.content.request.entity.GenerationRequest;
+import today_store.content.request.entity.InputImage;
+import today_store.content.request.repository.InputImageRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Comfy 웹훅 서비스 테스트")
+class ComfyWebhookServiceTest {
+
+    @Mock
+    private ApiLogRepository apiLogRepository;
+
+    @Mock
+    private InputImageRepository inputImageRepository;
+
+    @Mock
+    private InputImageVariationRepository variationRepository;
+
+    @Mock
+    private GcsService gcsService;
+
+    @Mock
+    private RunComfyService runComfyService;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private ComfyWebhookService comfyWebhookService;
+
+    @BeforeEach
+    void setUp() {
+        comfyWebhookService = new ComfyWebhookService(
+                apiLogRepository,
+                inputImageRepository,
+                variationRepository,
+                gcsService,
+                runComfyService,
+                webClient,
+                null,
+                eventPublisher
+        );
+    }
+
+    @Test
+    @DisplayName("성공 확정 이벤트 발행")
+    void shouldPublishTaskCompletedEventWhenFinalizeSuccess() {
+        // 이미지 변형 작업 성공 확정 시 ApiLog를 SUCCESS로 저장하고 커밋 이후 이메일 알림이 가능하도록 완료 이벤트를 발행해야 한다.
+
+        // given
+        UUID apiLogId = UUID.randomUUID();
+        UUID inputImageId = UUID.randomUUID();
+        User user = createUser("owner@example.com");
+        GenerationRequest request = createGenerationRequest(user);
+        ApiLog apiLog = createApiLog(apiLogId, request, ApiStatus.PROCESSING);
+        InputImage inputImage = createInputImage(inputImageId, request);
+        InputImageVariation existingVariation = createVariation(inputImage, "Wide shot", "stored/existing.png");
+        InputImageVariation duplicateVariation = createVariation(inputImage, "Wide shot", "stored/duplicate.png");
+        InputImageVariation newVariation = createVariation(inputImage, "Close up", "stored/new.png");
+
+        given(apiLogRepository.findByIdWithLock(apiLogId)).willReturn(Optional.of(apiLog));
+        given(inputImageRepository.findById(inputImageId)).willReturn(Optional.of(inputImage));
+        given(variationRepository.findByInputImageOrderByCreatedAtAsc(inputImage)).willReturn(List.of(existingVariation));
+
+        // when
+        comfyWebhookService.finalizeSuccess(apiLogId, inputImageId, List.of(duplicateVariation, newVariation));
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        assertThat(apiLog.getCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+        then(apiLogRepository).should().save(apiLog);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Iterable<InputImageVariation>> variationsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        then(variationRepository).should().saveAll(variationsCaptor.capture());
+        assertThat(variationsCaptor.getValue()).containsExactly(newVariation);
+
+        ArgumentCaptor<TaskCompletedEvent> eventCaptor = ArgumentCaptor.forClass(TaskCompletedEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getApiLogId()).isEqualTo(apiLogId);
+        assertThat(eventCaptor.getValue().getUserEmail()).isEqualTo("owner@example.com");
+        assertThat(eventCaptor.getValue().getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        assertThat(eventCaptor.getValue().getTaskType()).isEqualTo("COMFY_UI_VARIATION_V1");
+        assertThat(eventCaptor.getValue().getErrorMessage()).isNull();
+    }
+
+    @Test
+    @DisplayName("실패 확정 이벤트 발행")
+    void shouldPublishTaskCompletedEventWhenFinalizeFailure() {
+        // 이미지 변형 작업 실패 확정 시 에러 메시지를 저장하고 사용자에게 실패 알림을 보낼 수 있도록 완료 이벤트를 발행해야 한다.
+
+        // given
+        UUID apiLogId = UUID.randomUUID();
+        ApiLog apiLog = createApiLog(apiLogId, createGenerationRequest(createUser("owner@example.com")), ApiStatus.PROCESSING);
+        given(apiLogRepository.findByIdWithLock(apiLogId)).willReturn(Optional.of(apiLog));
+
+        // when
+        comfyWebhookService.finalizeFailure(apiLogId, "Verification failed or status mismatch");
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(apiLog.getErrorMessage()).isEqualTo("Verification failed or status mismatch");
+        then(apiLogRepository).should().save(apiLog);
+
+        ArgumentCaptor<TaskCompletedEvent> eventCaptor = ArgumentCaptor.forClass(TaskCompletedEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(eventCaptor.getValue().getErrorMessage()).isEqualTo("Verification failed or status mismatch");
+        assertThat(eventCaptor.getValue().getUserEmail()).isEqualTo("owner@example.com");
+    }
+
+    @Test
+    @DisplayName("중복 실패 확정 이벤트 미발행")
+    void shouldNotPublishEventWhenApiLogAlreadyFinished() {
+        // 이미 처리된 ApiLog를 중복 실패 처리할 때는 상태 저장과 이메일 이벤트 발행을 반복하지 않아야 한다.
+
+        // given
+        UUID apiLogId = UUID.randomUUID();
+        ApiLog apiLog = createApiLog(apiLogId, createGenerationRequest(createUser("owner@example.com")), ApiStatus.PROCESSING);
+        apiLog.completeSuccess(null, 0, 0, BigDecimal.ZERO, 0);
+        given(apiLogRepository.findByIdWithLock(apiLogId)).willReturn(Optional.of(apiLog));
+
+        // when
+        comfyWebhookService.finalizeFailure(apiLogId, "late failure");
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.SUCCESS);
+        then(apiLogRepository).should(never()).save(any());
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("예외 경로 오류 이벤트 발행")
+    void shouldPublishTaskCompletedEventWhenUpdatingApiLogToError() {
+        // 비동기 처리 중 예외가 발생해 별도 트랜잭션으로 ERROR 상태를 저장하는 경로도 이메일 알림 이벤트를 누락하지 않아야 한다.
+
+        // given
+        UUID apiLogId = UUID.randomUUID();
+        ApiLog apiLog = createApiLog(apiLogId, createGenerationRequest(createUser("owner@example.com")), ApiStatus.PROCESSING);
+        given(apiLogRepository.findById(apiLogId)).willReturn(Optional.of(apiLog));
+
+        // when
+        comfyWebhookService.updateApiLogToError(apiLogId, "System Error: storage unavailable");
+
+        // then
+        assertThat(apiLog.getStatus()).isEqualTo(ApiStatus.ERROR);
+        assertThat(apiLog.getErrorMessage()).isEqualTo("System Error: storage unavailable");
+        then(apiLogRepository).should().save(apiLog);
+        then(eventPublisher).should().publishEvent(any(TaskCompletedEvent.class));
+    }
+
+    private User createUser(String email) {
+        User user = new User(email, "테스트 사용자", "google", UUID.randomUUID().toString(), "https://image.test/profile.png");
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        return user;
+    }
+
+    private GenerationRequest createGenerationRequest(User user) {
+        GenerationRequest request = GenerationRequest.builder()
+                .user(user)
+                .concept("테스트 컨셉")
+                .build();
+        ReflectionTestUtils.setField(request, "id", UUID.randomUUID());
+        return request;
+    }
+
+    private ApiLog createApiLog(UUID apiLogId, GenerationRequest request, ApiStatus status) {
+        ApiLog apiLog = ApiLog.builder()
+                .generationRequest(request)
+                .model("COMFY_UI_VARIATION_V1")
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(apiLog, "id", apiLogId);
+        ReflectionTestUtils.setField(apiLog, "createdAt", LocalDateTime.of(2026, 5, 15, 9, 30));
+        return apiLog;
+    }
+
+    private InputImage createInputImage(UUID inputImageId, GenerationRequest request) {
+        InputImage inputImage = InputImage.builder()
+                .generationRequest(request)
+                .url("stored/input.png")
+                .description("원본 이미지")
+                .displayOrder(1)
+                .build();
+        ReflectionTestUtils.setField(inputImage, "id", inputImageId);
+        return inputImage;
+    }
+
+    private InputImageVariation createVariation(InputImage inputImage, String angleType, String url) {
+        return InputImageVariation.builder()
+                .inputImage(inputImage)
+                .angleType(angleType)
+                .url(url)
+                .build();
+    }
+}

--- a/backend-spring/today-store/src/test/java/today_store/user/controller/UserControllerWebMvcTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/user/controller/UserControllerWebMvcTest.java
@@ -99,17 +99,24 @@ class UserControllerWebMvcTest {
     @Test
     @DisplayName("내 프로필 수정 성공")
     void shouldUpdateMyProfile() throws Exception {
-        // 인증된 사용자가 이름을 수정하면 수정 응답을 반환해야 한다.
+        // 인증된 사용자가 프로필을 수정하면 변경된 사용자 정보와 토큰 응답 계약을 그대로 반환해야 한다.
 
         // given
         UUID userId = UUID.randomUUID();
         LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 14, 10);
         UpdateUserProfileResponse response = UpdateUserProfileResponse.builder()
                 .id(userId)
+                .email("new@example.com")
+                .name("새 이름")
+                .accessToken("new-access-token")
+                .refreshToken("new-refresh-token")
                 .updatedAt(updatedAt)
                 .build();
         given(userService.updateUserProfile(eq("user@example.com"), any())).willReturn(response);
-        String requestBody = objectMapper.writeValueAsString(java.util.Map.of("name", "새 이름"));
+        String requestBody = objectMapper.writeValueAsString(java.util.Map.of(
+                "name", "새 이름",
+                "email", "new@example.com"
+        ));
 
         // when
         MvcResult result = mockMvc.perform(patch("/api/v1/users/me")
@@ -123,10 +130,15 @@ class UserControllerWebMvcTest {
         // then
         assertThat(result.getResponse().getStatus()).isEqualTo(200);
         assertThat(body.get("id").asText()).isEqualTo(userId.toString());
+        assertThat(body.get("email").asText()).isEqualTo("new@example.com");
+        assertThat(body.get("name").asText()).isEqualTo("새 이름");
+        assertThat(body.get("accessToken").asText()).isEqualTo("new-access-token");
+        assertThat(body.get("refreshToken").asText()).isEqualTo("new-refresh-token");
         assertThat(LocalDateTime.parse(body.get("updatedAt").asText())).isEqualTo(updatedAt);
         then(userService).should().updateUserProfile(
                 eq("user@example.com"),
-                argThat(request -> request.getName().equals("새 이름"))
+                argThat(request -> request.getName().equals("새 이름")
+                        && request.getEmail().equals("new@example.com"))
         );
     }
 
@@ -152,6 +164,34 @@ class UserControllerWebMvcTest {
         assertThat(body.get("code").asText()).isEqualTo("U001");
         assertThat(body.get("message").asText()).isEqualTo("Invalid name format");
         assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("name");
+    }
+
+    @Test
+    @DisplayName("내 프로필 이메일 검증 오류")
+    void shouldReturnBadRequestWhenEmailIsInvalid() throws Exception {
+        // 이메일 변경 요청의 이메일 형식이 잘못되면 서비스 호출 없이 U001 검증 에러를 반환해야 한다.
+
+        // given
+        String requestBody = objectMapper.writeValueAsString(java.util.Map.of(
+                "name", "새 이름",
+                "email", "invalid-email"
+        ));
+
+        // when
+        MvcResult result = mockMvc.perform(patch("/api/v1/users/me")
+                        .header("X-Forwarded-For", CLIENT_IP)
+                        .principal(authenticationToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andReturn();
+        JsonNode body = readBody(result);
+
+        // then
+        assertThat(result.getResponse().getStatus()).isEqualTo(400);
+        assertThat(body.get("code").asText()).isEqualTo("U001");
+        assertThat(body.get("message").asText()).isEqualTo("Invalid name format");
+        assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("email");
+        then(userService).shouldHaveNoInteractions();
     }
 
     @Test

--- a/backend-spring/today-store/src/test/java/today_store/user/service/UserServiceTest.java
+++ b/backend-spring/today-store/src/test/java/today_store/user/service/UserServiceTest.java
@@ -2,21 +2,29 @@ package today_store.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
+import today_store.authentication.entity.RefreshToken;
 import today_store.authentication.entity.User;
 import today_store.authentication.jwt.JwtTokenProvider;
 import today_store.authentication.repository.RefreshTokenRepository;
@@ -45,6 +53,11 @@ class UserServiceTest {
     @BeforeEach
     void setUp() {
         userService = new UserService(userRepository, jwtTokenProvider, refreshTokenRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -126,7 +139,7 @@ class UserServiceTest {
     @Test
     @DisplayName("사용자 프로필 수정")
     void shouldUpdateUserProfile() {
-        // 사용자 이름을 변경하고 수정 응답을 반환해야 한다.
+        // 이메일 변경 없이 이름만 수정하면 기존 프로필 수정 계약을 유지하고 토큰을 재발급하지 않아야 한다.
 
         // given
         LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 11, 20);
@@ -145,9 +158,103 @@ class UserServiceTest {
 
         // then
         assertThat(user.getName()).isEqualTo("새 이름");
+        assertThat(user.getEmail()).isEqualTo("user@example.com");
         assertThat(response.getId()).isEqualTo(user.getId());
+        assertThat(response.getEmail()).isEqualTo("user@example.com");
+        assertThat(response.getName()).isEqualTo("새 이름");
+        assertThat(response.getAccessToken()).isNull();
+        assertThat(response.getRefreshToken()).isNull();
         assertThat(response.getUpdatedAt()).isEqualTo(updatedAt);
         then(userRepository).should().saveAndFlush(user);
+        then(userRepository).should(never()).existsByEmail(any());
+        then(jwtTokenProvider).should(never()).createAccessToken(any());
+        then(jwtTokenProvider).should(never()).createRefreshToken(any());
+        then(refreshTokenRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로필 이메일 변경")
+    void shouldUpdateEmailAndReissueTokensWhenEmailChanges() {
+        // 인증 주체로 쓰이는 이메일이 변경되면 중복 검증 후 새 이메일 기준 토큰을 재발급하고 Redis Refresh Token을 갱신해야 한다.
+
+        // given
+        LocalDateTime updatedAt = LocalDateTime.of(2026, 3, 30, 11, 30);
+        User user = createUser("old@example.com", "기존 이름");
+        UpdateUserProfileRequest request = UpdateUserProfileRequest.builder()
+                .name("새 이름")
+                .email("new@example.com")
+                .build();
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(
+                "old@example.com",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+        given(userRepository.findByEmail("old@example.com")).willReturn(Optional.of(user));
+        given(userRepository.existsByEmail("new@example.com")).willReturn(false);
+        given(userRepository.saveAndFlush(user)).willAnswer(invocation -> {
+            ReflectionTestUtils.setField(user, "updatedAt", updatedAt);
+            return user;
+        });
+        given(jwtTokenProvider.createAccessToken(any(Authentication.class))).willReturn("new-access-token");
+        given(jwtTokenProvider.createRefreshToken(any(Authentication.class))).willReturn("new-refresh-token");
+
+        // when
+        UpdateUserProfileResponse response = userService.updateUserProfile("old@example.com", request);
+
+        // then
+        assertThat(user.getEmail()).isEqualTo("new@example.com");
+        assertThat(user.getName()).isEqualTo("새 이름");
+        assertThat(response.getId()).isEqualTo(user.getId());
+        assertThat(response.getEmail()).isEqualTo("new@example.com");
+        assertThat(response.getName()).isEqualTo("새 이름");
+        assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("new-refresh-token");
+        assertThat(response.getUpdatedAt()).isEqualTo(updatedAt);
+
+        ArgumentCaptor<Authentication> authenticationCaptor = ArgumentCaptor.forClass(Authentication.class);
+        then(jwtTokenProvider).should().createAccessToken(authenticationCaptor.capture());
+        then(jwtTokenProvider).should().createRefreshToken(authenticationCaptor.capture());
+        assertThat(authenticationCaptor.getAllValues())
+                .extracting(Authentication::getName)
+                .containsOnly("new@example.com");
+        assertThat(authenticationCaptor.getAllValues().get(0).getAuthorities())
+                .extracting(Object::toString)
+                .containsExactly("ROLE_USER");
+
+        ArgumentCaptor<RefreshToken> refreshTokenCaptor = ArgumentCaptor.forClass(RefreshToken.class);
+        then(refreshTokenRepository).should().save(refreshTokenCaptor.capture());
+        assertThat(refreshTokenCaptor.getValue().getUserId()).isEqualTo(user.getId());
+        assertThat(refreshTokenCaptor.getValue().getRefreshToken()).isEqualTo("new-refresh-token");
+    }
+
+    @Test
+    @DisplayName("중복 이메일 변경 실패")
+    void shouldThrowWhenUpdatedEmailAlreadyExists() {
+        // 이미 사용 중인 이메일로 변경하려 하면 사용자 정보 저장과 토큰 재발급 없이 U002 예외를 반환해야 한다.
+
+        // given
+        User user = createUser("old@example.com", "기존 이름");
+        UpdateUserProfileRequest request = UpdateUserProfileRequest.builder()
+                .name("새 이름")
+                .email("duplicate@example.com")
+                .build();
+        given(userRepository.findByEmail("old@example.com")).willReturn(Optional.of(user));
+        given(userRepository.existsByEmail("duplicate@example.com")).willReturn(true);
+
+        // when
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> userService.updateUserProfile("old@example.com", request)
+        );
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS);
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS.getMessage());
+        assertThat(user.getEmail()).isEqualTo("old@example.com");
+        then(userRepository).should(never()).saveAndFlush(any());
+        then(jwtTokenProvider).should(never()).createAccessToken(any());
+        then(jwtTokenProvider).should(never()).createRefreshToken(any());
+        then(refreshTokenRepository).should(never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
## Issue Number
closed #91 

## As-Is
- 이메일 서비스 통합 이후 알림 매핑, 템플릿 처리, 이메일 발송 호출 흐름에 대한 테스트가 부족
- ComfyWebhookService의 작업 성공/실패/예외 처리 시 TaskCompletedEvent 발행 여부를 검증하는 테스트가 부족
- 사용자 프로필 이메일 변경 이후 중복 이메일 검증, 토큰 재발급, RefreshToken 저장, 응답 필드 매핑에 대한 테스트가 부족

## To-Be
- NotificationMapper, TaskNotificationListener, TaskCompletedEvent 테스트를 추가
- ComfyWebhookService의 성공/실패/예외 경로에서 작업 완료 이벤트가 발행되는지 검증
- UserService에서 이메일 변경 시 Access Token/Refresh Token 재발급 및 RefreshToken 저장을 검증
- 이름만 수정하는 경우 토큰이 재발급되지 않는 기존 동작을 검증
- UserController에서 프로필 수정 응답 필드와 이메일 형식 검증 실패 케이스를 보강

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
Trivy 스캔에서 `app/app.jar` 내 Java 의존성 취약점이 탐지되어 최소 범위로 의존성 버전을 상향
- `org.apache.tomcat.embed:tomcat-embed-core`
  - 기존: `10.1.54`
  - 변경: `10.1.55`
  - 대응 취약점: Tomcat 관련 CVE 다수
- `org.springframework.ai:spring-ai-bom`
  - 기존: `1.0.0`
  - 변경: `1.0.7`
  - 대응 취약점:
    - `CVE-2026-41712`
    - `CVE-2026-41713`