### PR TITLE
hotfix: remove @Async from TaskNotificationListener to fix email timeout

### DIFF
--- a/backend-spring/today-store/src/main/java/today_store/common/notification/TaskNotificationListener.java
+++ b/backend-spring/today-store/src/main/java/today_store/common/notification/TaskNotificationListener.java
@@ -2,7 +2,7 @@ package today_store.common.notification;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -22,7 +22,7 @@ public class TaskNotificationListener {
     private final NotificationMapper notificationMapper;
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    @Async
+
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTaskCompletedEvent(TaskCompletedEvent event) {
         log.info("Handling TaskCompletedEvent for apiLogId: {}, status: {}", event.getApiLogId(), event.getStatus());


### PR DESCRIPTION
Cloud Run의 'CPU allocated only during request processing' 모드에서 @Async로 실행되는 백그라운드 스레드가 CPU throttling을 받아
이메일 발송 시 SocketTimeoutException이 발생하는 문제 해결

- @Async 어노테이션 및 import 제거
- Webhook 요청 스레드에서 동기적으로 이메일 발송을 완료하도록 변경
- CPU가 활성 상태인 동안 Resend API 호출이 정상 수행됨

Refs: 로그 분석 결과 이벤트 발생(12:31:25)부터 이메일 시도(12:34:15)까지 약 2분 50초 지연 + Resend API 타임아웃(12:35:54) 확인
